### PR TITLE
181122urlパラメータ追加

### DIFF
--- a/potiboard/config.php
+++ b/potiboard/config.php
@@ -1,11 +1,17 @@
 <?php
 /*
-  * POTI-board改 v1.45.1 lot.180923
+  * POTI-board改 v1.45.3 lot.181122
   * by sakots >> https://sakots.red/poti/
   *
   * POTI-board改の設定ファイルです。
   *
 */
+/* ---------- ADD:2018/11/22 ---------- */
+//urlパラメータを追加する する:1 しない:0
+//ブラウザのキャッシュが表示されて投稿しても反映されない時は1。
+//.htaccessでキャッシュの有効期限を過去にしている場合は設定不要。
+
+define('URL_PARAMETER', '0');
 
 /* ---------- ADD:2018/09/22 ---------- */
 //シェアボタンを表示する する:1 しない:0
@@ -173,6 +179,7 @@ define('NOTICE_NOADMIN', '1');
 //メール通知先
 define('TO_MAIL', 'root@xxx.xxx');
 
+//メール通知のほか、シェアボタンなどで使用
 //設置場所のURL。'/'まで
 define('ROOT_URL', 'http://www.xxx.com/poti/');
 

--- a/potiboard/picpost.php
+++ b/potiboard/picpost.php
@@ -71,7 +71,7 @@ $u_agent = getenv("HTTP_USER_AGENT");
 $u_agent = str_replace("\t", "", $u_agent);
 
 //raw POST データ取得
-ini_set("always_populate_raw_post_data", "1");
+//ini_set("always_populate_raw_post_data", "1");
 //$buffer = $_REQUEST['HTTP_RAW_POST_DATA'];
 $buffer = file_get_contents('php://input');
 //if(!$buffer) $buffer = $HTTP_RAW_POST_DATA;


### PR DESCRIPTION
投稿後にブラウザのキャッシュを表示しないようにするため、urlパラメータを追加。
config.phpで設定。
ログの行数が20行以下の時に発生していた二重投稿チェックのNoticeを修正。
ログの行数が200行以下の時に発生していた画像重複チェックのNoticeを修正。
カタログモードのNoticeを修正。
動画のリンクをクリック時に動画が存在しなかった時の処理を変更。
picpost.phpの
//ini_set("always_populate_raw_post_data", "1");
 をコメントアウト。
半年以上コメントアウトした状態で運営して問題なく投稿できているのと、
すでにコメントアウトしている HTTP_RAW_POST_DATA を使う使わないの設定のため。
always_populate_raw_post_data を -1 にすると、将来のバージョンでの PHP の挙動を事前に体験できます。 
つまり、$HTTP_RAW_POST_DATA がはじめから定義されていない状態のことです。
http://php.net/manual/ja/ini.core.php#ini.always-populate-raw-post-data