### PR TITLE
181202メール通知クラス

### DIFF
--- a/potiboard/noticemail180605/euc-jp/noticemail.inc
+++ b/potiboard/noticemail180605/euc-jp/noticemail.inc
@@ -1,12 +1,13 @@
 <?php
 /*
-** メール通知クラス(EUC-JP) lot.180605
+** メール通知クラス(EUC-JP) lot.181202
 **
 ** http://www.punyu.net/php/
 ** by SakaQ
 ** https://sakots.red/poti/
 ** by sakots
 **
+** 2018/12/02 php7の静的コール警告エラー対応
 ** 2018/06/05 エラー対処
 ** 2018/01/15 php7対応改造
 ** 2007/03/01 件名(Subject)を日本語が含まれる場合にMIMEヘッダ変換するように変更
@@ -77,7 +78,7 @@ noticemail::send($data);
 
 class noticemail{
 
-	function send($data,$usemb="1"){
+	public static function send($data,$usemb="1"){
 		$name = $data['name'];
 		$from = $data['email'];
 		$line = "---------------------------------------------------------------------\n";

--- a/potiboard/noticemail180605/shift_jis/noticemail.inc
+++ b/potiboard/noticemail180605/shift_jis/noticemail.inc
@@ -1,12 +1,13 @@
 <?php
 /*
-** メール通知クラス(Shift_JIS) lot.180605
+** メール通知クラス(Shift_JIS) lot.181202
 **
 ** http://www.punyu.net/php/
 ** by SakaQ
 ** https://sakots.red/poti/
 ** by sakots
 **
+** 2018/12/02 php7の静的コール警告エラー対応
 ** 2018/06/05 エラー対処
 ** 2018/01/15 php7対応改造
 ** 2007/03/01 件名(Subject)を日本語が含まれる場合にMIMEヘッダ変換するように変更
@@ -77,7 +78,7 @@ noticemail::send($data);
 
 class noticemail{
 
-	function send($data,$usemb="1"){
+	public static function send($data,$usemb="1"){
 		$name = $data['name'];
 		$from = $data['email'];
 		$line = "---------------------------------------------------------------------\n";

--- a/potiboard/noticemail180605/utf-8/noticemail.inc
+++ b/potiboard/noticemail180605/utf-8/noticemail.inc
@@ -1,12 +1,13 @@
 <?php
 /*
-** メール通知クラス(UTF-8) lot.180605
+** メール通知クラス(UTF-8) lot.181202
 **
 ** http://www.punyu.net/php/
 ** by SakaQ
 ** https://sakots.red/poti/
 ** by sakots
 **
+** 2018/12/02 php7の静的コール警告エラー対応
 ** 2018/06/05 エラー対処
 ** 2018/01/15 php7対応改造
 ** 2007/03/01 件名(Subject)を日本語が含まれる場合にMIMEヘッダ変換するように変更
@@ -77,7 +78,7 @@ noticemail::send($data);
 
 class noticemail{
 
-	function send($data,$usemb="1"){
+	public static function send($data,$usemb="1"){
 		$name = $data['name'];
 		$from = $data['email'];
 		$line = "---------------------------------------------------------------------\n";

--- a/potiboard/potiboard.php
+++ b/potiboard/potiboard.php
@@ -1,7 +1,7 @@
 <?php
 /*
   *
-  * POTI-board改 v1.45.5 lot.181129
+  * POTI-board改 v1.45.6 lot.181202
   *   (C)sakots >> https://sakots.red/poti/
   *
   *----------------------------------------------------------------------------------
@@ -68,8 +68,8 @@ if((THUMB_SELECT==0 && gd_check()) || THUMB_SELECT==1){
 define('USE_MB' , '1');
 
 //バージョン
-define('POTI_VER' , '改 v1.45.5');
-define('POTI_VERLOT' , '改 v1.45.5 lot.181129');
+define('POTI_VER' , '改 v1.45.6');
+define('POTI_VERLOT' , '改 v1.45.6 lot.181202');
 
 //メール通知クラスのファイル名
 define('NOTICEMAIL_FILE' , 'noticemail.inc');
@@ -984,6 +984,9 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 			if(RENZOKU && $time - $ltime < RENZOKU){error(MSG020,$dest);}
 			if(RENZOKU2 && $time - $ltime < RENZOKU2 && $upfile_name){error(MSG021,$dest);}
 			if(isset($com)){
+				if(isset($textonly) && $textonly){//画像なしの時
+				$dest="";
+				}
 				switch(D_POST_CHECKLEVEL){
 					case 1:	//low
 						if($com == $lcom){error(MSG022,$dest);}
@@ -1039,7 +1042,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 		}//ここまで
 	list($lastno,) = explode(",", $line[0]);
 	$no = $lastno + 1;
-	if(!isset($dest)){
+	if(isset($textonly) && $textonly){
 	$dest=$ext=$W=$H=$chk="";
 	}
 	$newline = "$no,$now,$name,$email,$sub,$com,$url,$host,$pass,$ext,$W,$H,$tim,$chk,$ptime,$fcolor\n";


### PR DESCRIPTION
noticemail.incのphp7の静的コールの警告への対応。
画像なしにチェックをいれて投稿して二重投稿のエラーの時にNoticeが発生していたので画像なし=$textonlyがtrueの時処理を変更。
それにともない、画像に関する変数$destが未定義かどうかで処理していた箇所を
$textonlyによる処理に変更。