### PR TITLE
Chrome68のオートフィルに対処

### DIFF
--- a/potiboard/htmltemplate.inc
+++ b/potiboard/htmltemplate.inc
@@ -311,7 +311,7 @@ class htmltemplate{
 //http://jp2.php.net/manual/ja/language.oop5.static.php
 //2018.09.22
 
-	public static function &getInstance(){
+	private static function &getInstance(){
 		static $instance;
 		if(! $instance) $instance=new htmltemplate();
 		return $instance;

--- a/potiboard/nee_catalog.html
+++ b/potiboard/nee_catalog.html
@@ -110,7 +110,7 @@
 				UseFunction -
 				<a href="http://hoover.ktplan.ne.jp/kaihatsu/php/" target="_top"title="HTML template v1.3.2 (by The PHP Den)">HTML template</a>
 				<a href="http://wondercatstudio.com/" target="_top" title="by WonderCatStudio">DynamicPalette</a>
-				<a href="https://github.com/funige/neo/" target="_top" title="by ImageCanvas">PaintBBS NEO</a>
+				<a href="https://github.com/funige/neo/" target="_top" title="by funige">PaintBBS NEO</a>
 			</p>
 		</footer>
 	</body>

--- a/potiboard/nee_main.html
+++ b/potiboard/nee_main.html
@@ -52,7 +52,7 @@
 							<!--{/def}--><?php echo "\n"; ?>
 							<input type="hidden" name="mode" value="paint">
 							<input class="button" type="submit" value="お絵かき">
-							<!--{def anime}--><input type="checkbox" value="true" name="anime" title="動画記録"><!--{/def}--><?php echo "\n"; ?>
+							<!--{def anime}--><input type="checkbox" value="true" name="anime"{$animechk} title="動画記録"><!--{/def}--><?php echo "\n"; ?>
 						</p>
 					</form>
 				</section>
@@ -71,7 +71,7 @@
 							</tr>
 							<tr>
 								<td>URL</td>
-								<td><input class="form" type="text" name="url" size="28" autocomplete="url"></td>
+								<td><input class="form" type="url" name="url" size="28" autocomplete="url"></td>
 							</tr>
 							<tr>
 								<td>sage</td>
@@ -120,8 +120,8 @@
 			<section>
 				<form class="delf" action="{$self}" method="post">
 					<p>
-						No <input class="form" type="text" name="del[]" value="" autocomplete="section-no">
-						Pass <input class="form" type="password" name="pwd" value="" autocomplete="new-password">
+						No <input class="form" type="number" min="1" name="del[]" value="" autocomplete="off">
+						Pass <input class="form" type="password" name="pwd" value="" autocomplete="current-password">
 						<select class="form" name="mode" tabindex="1">
 							<option value="edit" selected>編集</option>
 							<!--{def userdel}--><?php echo "\n"; ?>
@@ -204,7 +204,7 @@
 								<input type="hidden" name="textonly" value="on">
 								<label>name{$usename} <input class="form" type="text" name="name" size="20" value="" autocomplete="username"></label>
 								<label>sub{$usesub} <input class="form" type="text" name="sub" size="18" value="{$oya/resub}" autocomplete="section-sub"></label><br>
-								<label>URL <input class="form" type="text" name="url" size="20" autocomplete="url"></label>
+								<label>URL <input class="form" type="url" name="url" size="20" autocomplete="url"></label>
 								<label>sage <input class="form" type="text" name="email" size="8" autocomplete="email"></label>
 								<label>Pass <input class="form" type="password" name="pwd" size="8" value="" autocomplete="current-password"></label>
 								<input class="button" type="submit" value="返信">
@@ -240,7 +240,7 @@
 				UseFunction -
 				<a href="http://hoover.ktplan.ne.jp/kaihatsu/php/" target="_top" title="HTML template v1.3.2 (by The PHP Den)">HTML template</a>
 				<a href="http://wondercatstudio.com/" target="_top" title="by WonderCatStudio">DynamicPalette</a>
-				<a href="https://github.com/funige/neo/" target="_top" title="by ImageCanvas">PaintBBS NEO</a>
+				<a href="https://github.com/funige/neo/" target="_top" title="by funige">PaintBBS NEO</a>
 			</p>
 		</footer>
 	</body>

--- a/potiboard/nee_other.html
+++ b/potiboard/nee_other.html
@@ -61,7 +61,7 @@
 							</tr>
 							<tr>
 								<td>URL</td><td>
-									<input class="form" type="text" name="url" size="28" autocomplete="url"<!--{def url}--> value="{$url}"<!--{/def}-->></td>
+									<input class="form" type="url" name="url" size="28" autocomplete="url"<!--{def url}--> value="{$url}"<!--{/def}-->></td>
 							</tr>
 							<tr>
 								<td>sub{$usesub}</td>
@@ -236,7 +236,7 @@
 				UseFunction -
 				<a href="http://hoover.ktplan.ne.jp/kaihatsu/php/" target="_top"title="HTML template v1.3.2 (by The PHP Den)">HTML template</a>
 				<a href="http://wondercatstudio.com/" target="_top" title="by WonderCatStudio">DynamicPalette</a>
-				<a href="https://github.com/funige/neo/" target="_top" title="by ImageCanvas">PaintBBS NEO</a>
+				<a href="https://github.com/funige/neo/" target="_top" title="by funige">PaintBBS NEO</a>
 			</p>
 		</footer>
 	</body>

--- a/potiboard/nee_paint.html
+++ b/potiboard/nee_paint.html
@@ -568,7 +568,7 @@
 							<option value="rep">replace</option>
 							<option value="new">newpost</option>
 						</select>
-						<!--{def passflag}-->Pass<input class="form" type="password" name="pwd" size="8" value=""> <!--{/def}--><?php echo "\n"; ?>
+						<!--{def passflag}-->Pass<input class="form" type="password" name="pwd" size="8" value="" autocomplete="current-password"> <!--{/def}--><?php echo "\n"; ?>
 						<input class="button" type="submit" value="続きを描く">
 					</form>
 					<!--{def passflag}--><?php echo "\n"; ?>
@@ -608,7 +608,7 @@
 				UseFunction -
 				<a href="http://hoover.ktplan.ne.jp/kaihatsu/php/" target="_top"title="HTML template v1.3.2 (by The PHP Den)">HTML template</a>
 				<a href="http://wondercatstudio.com/" target="_top" title="by WonderCatStudio">DynamicPalette</a>
-				<a href="https://github.com/funige/neo/" target="_top" title="by ImageCanvas">PaintBBS NEO</a>
+				<a href="https://github.com/funige/neo/" target="_top" title="by funige">PaintBBS NEO</a>
 			</p>
 		</footer>
 	</body>


### PR DESCRIPTION
テンプレート。

Chrome68からautocomplete="new-password"は新規パスワードなので新しいパスワードを生成という挙動に変わったため、オートフィル抑止目的での使用をやめました。代わりに、記事のメンテナンスで使うinputを、textからnumberに変更。
ユーザー名=名前が数字以外の場合はそこにユーザー名が入らないようにしました。
アニメ保存チェックありなしの変数を追加しました。

htmltemplate.inc。

一箇所だけですがprivateにする事が可能でしたので、publicからprivateに変更しました。