### PR TITLE
lot.190528

### DIFF
--- a/potiboard/nee_catalog.html
+++ b/potiboard/nee_catalog.html
@@ -49,7 +49,7 @@
 				<section>
 					<form class="delf" action="{$self}" method="post">
 						<p>
-							No <input class="form" type="number" min="1" name="del[]" size="4" value="" autocomplete="section-no">
+							No <input class="form" type="number" min="1" name="del[]" size="4" value="" autocomplete="off">
 							Pass <input class="form" type="password" name="pwd" size="6" value="" autocomplete="current-password">
 							<select class="form" name="mode">
 								<option value="edit" selected>編集</option>

--- a/potiboard/nee_main.html
+++ b/potiboard/nee_main.html
@@ -139,7 +139,7 @@
 			<section>
 				<form class="delf" action="{$self}" method="post">
 					<p>
-						No <input class="form" type="number" min="1" name="del[]" value="" autocomplete="section-no">
+						No <input class="form" type="number" min="1" name="del[]" value="" autocomplete="off">
 						Pass <input class="form" type="password" name="pwd" value="" autocomplete="current-password">
 						<select class="form" name="mode" tabindex="1">
 							<option value="edit" selected>編集</option>

--- a/potiboard/nee_paint.html
+++ b/potiboard/nee_paint.html
@@ -481,7 +481,6 @@
 						</fieldset>
 						<fieldset>
 							<legend>MATRIX</legend>
-							<form>
 							<select class="form" name="m_m">
 								<option value="0">全体</option>
 								<option value="1">現在</option>
@@ -535,7 +534,6 @@
 							</form>
 						</fieldset>
 						<p class="c"><a href="http://wondercatstudio.com/" target="_blank" title="WonderCatStudio">DynamicPalette &copy;NoraNeko</a></p>
-					</form>
 				</div>
 			</section>
 			<section>

--- a/potiboard/neo.css
+++ b/potiboard/neo.css
@@ -545,3 +545,111 @@
     border: 1px solid #b1d6fd;
 }
 
+/*
+-----------------------
+	Viewer
+-----------------------
+*/
+
+.NEO #viewerButtonsWrapper {
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+    width: 100%;
+    height: 24px;
+    border: 1px solid red;
+    margin:0;
+    padding:0;
+}
+
+.NEO #viewerButtons {
+    width: calc(100% - 2px);
+    height: 22px;
+    border: 1px solid white;
+    font-size: 0;
+    text-align: left;
+
+    margin: 0;
+    padding: 0;
+    //padding-top: 2px;
+    //padding-left: 2px;
+
+    overflow: hidden;
+}
+
+.NEO #viewerButtons > div {
+    margin: 0;
+    padding: 0;
+    width: 18px;
+    height: 18px;
+    overflow: hidden;
+    margin-top: 1px;
+    margin-left: 2px;
+
+    font-size: 14px;
+    font-weight: 100;
+    font-family: 'Arial';
+    letter-spacing: 0;
+    -webkit-font-smoothing: antialiased;
+    font-smoothing: antialiased;
+}
+
+.NEO #viewerButtons >div.buttonOff {
+    display: inline-block;
+    border: 1px solid black;
+    width: 18px;
+    height: 18px;
+    background-color: red;
+    
+    border-left: 1px solid rgba(0, 0, 0, 1);
+    border-top: 1px solid rgba(0, 0, 0, 1);
+    border-right: 1px solid rgba(0, 0, 0, 1);
+    border-bottom: 1px solid rgba(0, 0, 0, 1);
+}
+
+.NEO #viewerButtons >div.buttonOff:hover {}
+
+.NEO #viewerButtons >div.buttonOff:active,
+.NEO #viewerButtons >div.buttonOn {
+    display: inline-block;
+    border: 1px solid black;
+    width: 18px;
+    height: 18px;
+    background-color: grey;
+
+    border-right: 1px solid rgba(0, 0, 0, 1);
+    border-bottom: 1px solid rgba(0, 0, 0, 1);
+}
+
+.NEO #viewerButtons canvas {
+    max-width: 24px;
+    margin-left: 1px;
+    margin-top: 1px;
+}
+
+.NEO #viewerBarLeft {
+    pointer-events: none;
+    width: calc(100% - 2px);
+    height: 16px;
+    position: absolute;
+    top: 1px;
+    left: 1px;
+}
+
+.NEO #viewerBarMark {
+    pointer-events: none;
+    width: 1px;
+    height: 16px;
+    position: absolute;
+    top: 1px;
+    left: 1px;
+}
+
+.NEO #viewerBarText {
+    pointer-events: none;
+    position: absolute;
+    top: 0px;
+    left: 1px;
+    background-color: rgba(0, 0, 0, 0) !important;
+}
+

--- a/potiboard/neo.js
+++ b/potiboard/neo.js
@@ -3,14 +3,14 @@
 document.addEventListener("DOMContentLoaded", function() {
     Neo.init();
 
-    if (!navigator.userAgent.match("Electron") && !Neo.viewer) {
+    if (!navigator.userAgent.match("Electron")) {
         Neo.start();
     }
 });
 
 var Neo = function() {};
 
-Neo.version = "1.4.5";
+Neo.version = "1.5.1";
 Neo.painter;
 Neo.fullScreen = false;
 Neo.uploaded = false;
@@ -54,24 +54,24 @@ Neo.init = function() {
 
         if (name == "paintbbs" || name == "pch") {
             Neo.applet = applet;
-            Neo.initConfig(applet);
 
             if (name == "paintbbs") {
+                Neo.initConfig(applet);
                 Neo.createContainer(applet);
                 Neo.init2();
 
             } else {
-                var pch = Neo.getPCH(function(pch) {
+                Neo.viewer = true;
+                Neo.initConfig(applet);
+
+                var filename = Neo.getFilename();
+                var pch = Neo.getPCH(filename, function(pch) {
                     if (pch) {
-                        console.log('pch:', pch);
-                        Neo.viewer = true;
                         Neo.createViewer(applet);
                         Neo.config.width = pch.width;
                         Neo.config.height = pch.height;
-
-                        Neo.initViewer();
-                        
-                        applet.parentNode.removeChild(applet)
+                        Neo.initViewer(pch);
+                        Neo.startViewer();
                     }
                 });
             }
@@ -152,6 +152,10 @@ Neo.initConfig = function(applet) {
         var emulationMode = Neo.config.neo_emulation_mode || "2.22_8x";
         Neo.config.neo_alt_translation = emulationMode.slice(-1).match(/x/i);
 
+        if (Neo.viewer && !Neo.config.color_bar) {
+            Neo.config.color_bar = "#eeeeff";
+        }
+
         Neo.readStyles();
         Neo.applyStyle("color_bk", "#ccccff");
         Neo.applyStyle("color_bk2", "#bbbbff");
@@ -166,6 +170,12 @@ Neo.initConfig = function(applet) {
         Neo.applyStyle("tool_color_bar", "#ddddff");
         Neo.applyStyle("tool_color_frame", "#000000");
 
+        // viewer用
+        if (Neo.viewer) {
+            Neo.applyStyle("color_back", "#ccccff");
+            Neo.applyStyle("color_bar_select", "#407675");
+        }
+        
         var e = document.getElementById("container");
         Neo.config.inherit_color = Neo.getInheritColor(e);
         if (!Neo.config.color_frame) Neo.config.color_frame = Neo.config.color_text;
@@ -201,21 +211,23 @@ Neo.fixConfig = function(value) {
     return value;
 };
 
-Neo.initSkin = function() {
+Neo.getStyleSheet = function() {
     var sheet = document.styleSheets[0];
     if (!sheet) {
         var style = document.createElement("style");
         document.head.appendChild(style); // must append before you can access sheet property
         sheet = style.sheet;
     }
+    return sheet;
+};
 
-    Neo.styleSheet = sheet;
-
+Neo.initSkin = function() {
+    Neo.styleSheet = Neo.getStyleSheet();
     var lightBorder = Neo.multColor(Neo.config.color_icon, 1.3);
     var darkBorder = Neo.multColor(Neo.config.color_icon, 0.7);
     var lightBar = Neo.multColor(Neo.config.color_bar, 1.3);
     var darkBar = Neo.multColor(Neo.config.color_bar, 0.7);
-    var bgImage = Neo.backgroundImage();
+    var bgImage = Neo.painter ? Neo.backgroundImage() : "";
 
     Neo.addRule(".NEO #container", "background-image", "url(" + bgImage + ")");
     Neo.addRule(".NEO .colorSlider .label", "color", Neo.config.tool_color_text);
@@ -513,10 +525,11 @@ Neo.initButtons = function() {
 };
 
 Neo.start = function(isApp) {
-    if (!Neo.painter) return;
-    
+    if (Neo.viewer) return;
+
     Neo.initSkin();
     Neo.initComponents();
+
     Neo.initButtons();
 
     Neo.isApp = isApp;
@@ -670,6 +683,11 @@ Neo.resizeCanvas = function() {
     width = Math.floor(width / 2) * 2;
     height = Math.floor(height / 2) * 2;
 
+    if (Neo.viewer) {
+        width = canvasWidth;
+        height = canvasHeight;
+    }
+    
     Neo.painter.destWidth = width;
     Neo.painter.destHeight = height;
 
@@ -780,8 +798,10 @@ Neo.submit = function(board, blob, thumbnail, thumbnail2) {
     request.open("POST", url, true);
     
     request.onload = function(e) {
-        console.log(request.response);
-        Neo.uploaded = true;
+        console.log(request.response, 'status=', request.status);
+        if (request.status / 100 == 2) {
+            Neo.uploaded = true;
+        }
 
         var url = Neo.config.url_exit;
         if (url[0] == '/') {
@@ -975,125 +995,24 @@ Neo.createContainer = function(applet) {
     }, 0);
 };
 
-/*
-  -----------------------------------------------------------------------
-    動画表示モード
-  -----------------------------------------------------------------------
-*/
-
-Neo.createViewer = function(applet) {
-    var neo = document.createElement("div");
-    neo.className = "NEO";
-    neo.id = "NEO";
-    var html = (function() {/*
-<script src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
-
-<div id="pageView" style="margin:auto;">
-<div id="container" style="visibility:visible;" class="o">
-
-<div id="painter" style="background-color:white;">
-<div id="canvas" style="background-color:white;">
-</div>
-</div>
-
-</div>
-</div>
-                                 */}).toString().match(/\/\*([^]*)\*\//)[1];
-
-    neo.innerHTML = html.replace(/\[(.*?)\]/g, function(match, str) {
-	return Neo.translate(str)
-    })
+Neo.tintImage = function(ctx, c) {
+    c = (Neo.painter.getColor(c) & 0xffffff);
     
-    var parent = applet.parentNode;
-    parent.appendChild(neo);
-    parent.insertBefore(neo, applet);
+    var imageData = ctx.getImageData(0, 0, 46, 18);
+    var buf32 = new Uint32Array(imageData.data.buffer);
+    var buf8 = new Uint8ClampedArray(imageData.data.buffer);
 
-    // applet.style.display = "none";
-
-    // NEOを組み込んだURLをアプリ版で開くとDOMツリーが2重にできて格好悪いので消しておく
-    setTimeout(function() {
-        var tmp = document.getElementsByClassName("NEO");
-        if (tmp.length > 1) {
-            for (var i = 1; i < tmp.length; i++) {
-                tmp[i].style.display = "none";
-            }
-        }
-    }, 0);
-};
-
-Neo.initViewer = function() {
-    var pageview = document.getElementById("pageView");
-    var pageWidth = Neo.config.applet_width;
-    var pageHeight = Neo.config.applet_height;
-    pageview.style.width = pageWidth + "px";
-    pageview.style.height = pageHeight + "px";
-    
-    Neo.canvas = document.getElementById("canvas");
-    Neo.container = document.getElementById("container");
-//  Neo.container.style.backgroundColor = Neo.config.color_bk;
-    Neo.container.style.border = "0";
-
-    var dx = (pageWidth - Neo.config.width) / 2;
-    var dy = (pageHeight - Neo.config.height - 26) / 2;
-    
-    var painter = document.getElementById("painter");
-
-    painter.style.marginTop = "0";
-    painter.style.position = "absolute";
-    painter.style.padding = "0";
-    painter.style.bottom = (dy + 26) + "px";
-    painter.style.left = (dx) + "px";
-
-
-    Neo.canvas.style.width = Neo.config.width + "px";
-    Neo.canvas.style.height = Neo.config.height + "px";
-    
-    Neo.painter = new Neo.Painter();
-    Neo.painter.build(Neo.canvas, Neo.config.width, Neo.config.height);
-    
-    Neo.container.oncontextmenu = function() {return false;};
-
-    if (Neo.config.pch_file) {
-        Neo.painter.loadAnimation(Neo.config.pch_file, 10)
-    }        
-};
-
-Neo.getFilename = function() {
-    return Neo.config.pch_file || Neo.config.image_canvas;
-};
-
-Neo.getPCH = function(callback) {
-    var filename = Neo.getFilename();
-    if (!filename || filename.slice(-4).toLowerCase() != ".pch") return null;
-    
-    var request = new XMLHttpRequest();
-    request.open("GET", filename, true);
-    request.responseType = "arraybuffer";
-    request.onload = function() {
-        var byteArray = new Uint8Array(request.response);
-        var data = LZString.decompressFromUint8Array(byteArray.slice(12));
-        var header = byteArray.slice(0, 12);
-
-        if ((header[0] == "N".charCodeAt(0)) &&
-            (header[1] == "E".charCodeAt(0)) &&
-            (header[2] == "O".charCodeAt(0))) {
-            var width = header[4] + header[5] * 0x100
-            var height = header[6] + header[7] * 0x100
-            console.log('NEO animation:', width, 'x', height);
-            if (callback) {
-                callback({
-                    width:width,
-                    height:height,
-                    data:JSON.parse(data)
-                });
-            }
-            
-        } else {
-            console.log('not a NEO animation:');
+    for (var i = 0; i < buf32.length; i++) {
+        var a = buf32[i] & 0xff000000;
+        if (a) {
+            buf32[i] = buf32[i] & a | c;
         }
     }
-    request.send();
+    imageData.data.set(buf8);
+    ctx.putImageData(imageData, 0, 0);
 };
+
+
 
 'use strict';
 
@@ -1143,8 +1062,11 @@ Neo.dictionary = {
         "このブラウザでは<br>投稿に失敗することがあります<br>": "This browser may fail to send your picture.<br>",
 
         "画像を投稿しますか？<br>投稿に成功後、編集を終了します。": "Is the picture contributed?<br>if contribution completed, you jump to the comment page.",
-//      "PaintBBS NEOではこの動画の続きを描くことはできません": "PaintBBS NEO can't handle this animation data.",
         "描きかけの画像があります。動画の読み込みを中止して復元しますか？": "Discard animation data and restore session?",
+        "最": "Mx", 
+        "早": "H", 
+        "既": "M", 
+        "鈍": "L", 
     },
     "enx": {
 	"やり直し": "Redo",
@@ -1192,8 +1114,11 @@ Neo.dictionary = {
         "このブラウザでは<br>投稿に失敗することがあります<br>": "This browser may fail to send your picture.<br>",
 
         "画像を投稿しますか？<br>投稿に成功後、編集を終了します。": "Send this picture and end session?",
-//      "PaintBBS NEOではこの動画の続きを描くことはできません": "PaintBBS NEO can't handle this animation data.",
         "描きかけの画像があります。動画の読み込みを中止して復元しますか？": "Discard animation data and restore session?",
+        "最": "Mx", 
+        "早": "H", 
+        "既": "M", 
+        "鈍": "L", 
     },
     "es": {
 	"やり直し": "Rehacer",
@@ -1242,8 +1167,11 @@ Neo.dictionary = {
         "このブラウザでは<br>投稿に失敗することがあります<br>": "Este navegador podría no enviar su imagen.<br>",
 
         "画像を投稿しますか？<br>投稿に成功後、編集を終了します。": "¿Enviar esta imagen y finalizar sesión?",
-//      "PaintBBS NEOではこの動画の続きを描くことはできません": "PaintBBS NEO no puede analizar estos datos de animación.",
         "描きかけの画像があります。動画の読み込みを中止して復元しますか？": "¿Desechar datos de animación y restaurar sesión?",
+        "最": "Mx", 
+        "早": "H", 
+        "既": "M", 
+        "鈍": "L", 
     },
 };
 
@@ -1345,6 +1273,8 @@ Neo.Painter.prototype._currentMask = [];
 
 Neo.Painter.prototype.aerr;
 Neo.Painter.prototype.dirty = false;
+Neo.Painter.prototype.busy = false;
+Neo.Painter.prototype.busySkipped = false;
 
 Neo.Painter.LINETYPE_NONE = 0;
 Neo.Painter.LINETYPE_PEN = 1;
@@ -1353,6 +1283,7 @@ Neo.Painter.LINETYPE_BRUSH = 3;
 Neo.Painter.LINETYPE_TONE = 4;
 Neo.Painter.LINETYPE_DODGE = 5;
 Neo.Painter.LINETYPE_BURN = 6;
+Neo.Painter.LINETYPE_BLUR = 7;
 
 Neo.Painter.MASKTYPE_NONE = 0;
 Neo.Painter.MASKTYPE_NORMAL = 1;
@@ -1533,26 +1464,28 @@ Neo.Painter.prototype._initCanvas = function(div, width, height) {
 
     var ref = this;
 
-    var container = document.getElementById("container");
+    if (!Neo.viewer) {
+        var container = document.getElementById("container");
 
-    container.onmousedown = function(e) {ref._mouseDownHandler(e)};
-    container.onmousemove = function(e) {ref._mouseMoveHandler(e)};
-    container.onmouseup = function(e) {ref._mouseUpHandler(e)};
-    container.onmouseover = function(e) {ref._rollOverHandler(e)};
-    container.onmouseout = function(e) {ref._rollOutHandler(e)};
-    container.addEventListener("touchstart", function(e) {
-        ref._mouseDownHandler(e);
-    }, false);
-    container.addEventListener("touchmove", function(e) {
-        ref._mouseMoveHandler(e);
-    }, false);
-    container.addEventListener("touchend", function(e) {
-        ref._mouseUpHandler(e);
-    }, false);
+        container.onmousedown = function(e) {ref._mouseDownHandler(e)};
+        container.onmousemove = function(e) {ref._mouseMoveHandler(e)};
+        container.onmouseup = function(e) {ref._mouseUpHandler(e)};
+        container.onmouseover = function(e) {ref._rollOverHandler(e)};
+        container.onmouseout = function(e) {ref._rollOutHandler(e)};
+        container.addEventListener("touchstart", function(e) {
+            ref._mouseDownHandler(e);
+        }, false);
+        container.addEventListener("touchmove", function(e) {
+            ref._mouseMoveHandler(e);
+        }, false);
+        container.addEventListener("touchend", function(e) {
+            ref._mouseUpHandler(e);
+        }, false);
 
-    document.onkeydown = function(e) {ref._keyDownHandler(e)};
-    document.onkeyup = function(e) {ref._keyUpHandler(e)};
-
+        document.onkeydown = function(e) {ref._keyDownHandler(e)};
+        document.onkeyup = function(e) {ref._keyUpHandler(e)};
+    }
+    
     this.updateDestCanvas(0, 0, this.canvasWidth, this.canvasHeight);
 };
 
@@ -1718,6 +1651,14 @@ Neo.Painter.prototype._rollOutHandler = function(e) {
 };
 
 Neo.Painter.prototype._mouseDownHandler = function(e) {
+    if (this.busy) {
+        // loadAnimation実行中は何もしない
+        if (e.target == Neo.painter.destCanvas) {
+            this.busySkipped = true;
+        }
+        return;
+    }
+
     if (e.target == Neo.painter.destCanvas) {
         //よくわからないがChromeでドラッグの時カレットが出るのを防ぐ
         //http://stackoverflow.com/questions/2745028/chrome-sets-cursor-to-text-while-dragging-why    
@@ -2091,6 +2032,14 @@ Neo.Painter.prototype.setZoomPosition = function(x, y) {
 */
 
 Neo.Painter.prototype.submit = function(board) {
+    if (Neo.animation) { // neo_save_layers
+        var items = this._actionMgr._items;
+        if (items.length > 0 && items[items.length - 1][0] != 'restore') {
+            this._pushUndo();
+            this._actionMgr.restore();
+        }
+    }
+
     var thumbnail = null;
     var thumbnail2 = null;
 
@@ -2665,7 +2614,7 @@ Neo.Painter.prototype.setEraserPoint = function(buf8, width, x, y) {
     var shape = this._roundData[d];
     var shapeIndex = 0;
     var index = (y * width + x) * 4;
-    var a = Math.floor(this.alpha * 255);
+    var a = Math.floor(this._currentColor[3]); //this.alpha * 255);
 
     for (var i = 0; i < d; i++) {
         for (var j = 0; j < d; j++) {
@@ -2691,7 +2640,8 @@ Neo.Painter.prototype.setBlurPoint = function(buf8, width, x, y, x0, y0) {
     var height = buf8.length / (width * 4);
 
 //  var a1 = this.getAlpha(Neo.Painter.ALPHATYPE_BRUSH);
-    var a1 = this.alpha / 12;
+//  var a1 = this.alpha / 12;
+    var a1 = (this._currentColor[3] / 255.0) / 12;
     if (a1 == 0) return;
     var blur = a1;
 
@@ -2857,16 +2807,19 @@ Neo.Painter.prototype.getBezierPoint = function(t, x0, y0, x1, y1, x2, y2, x3, y
 
 var nmax = 1;
 
-Neo.Painter.prototype.drawBezier = function(ctx, x0, y0, x1, y1, x2, y2, x3, y3, type) {
+Neo.Painter.prototype.drawBezier = function(ctx, x0, y0, x1, y1, x2, y2, x3, y3, type, isReplay) {
     var xmax = Math.max(x0, x1, x2, x3);
     var xmin = Math.min(x0, x1, x2, x3);
     var ymax = Math.max(y0, y1, y2, y3);
     var ymin = Math.min(y0, y1, y2, y3);
     var n = Math.ceil(((xmax - xmin) + (ymax - ymin)) * 2.5);
 
-    if (n > nmax) {
-        n = (n < nmax * 2) ? n : nmax * 2;
-        nmax = n;
+    // 最初にベジェを使う時ここで処理落ちするため
+    if (!isReplay) {
+        if (n > nmax) {
+            n = (n < nmax * 2) ? n : nmax * 2;
+            nmax = n;
+        }
     }
 
     for (var i = 0; i < n; i++) {
@@ -3091,7 +3044,7 @@ Neo.Painter.prototype.eraseRect = function(layer, x, y, width, height) {
 
     var index = 0;
 
-    var a = 1.0 - this.alpha;
+    var a = 1.0 - (this._currentColor[3] / 255.0) //this.alpha;
     if (a != 0) {
         a = Math.ceil(2.0 / a);
     } else {
@@ -3228,7 +3181,7 @@ Neo.Painter.prototype.blurRect = function(layer, x, y, width, height) {
     for (var i = 0; i < buf8.length; i++) tmp[i] = buf8[i];
 
     var index = 0;
-    var a1 = this.alpha / 12;
+    var a1 = (this._currentColor[3] / 255.0) / 12; //this.alpha / 12;
     var blur = a1;
 
     for (var j = 0; j < height; j++) {
@@ -3638,10 +3591,6 @@ Neo.Painter.prototype.cancelTool = function(e) {
 };
 
 Neo.Painter.prototype.loadImage = function (filename) {
-    if (filename.slice(-3).toLowerCase == ".pch") {
-        return this.loadAnimation(filename);
-    }
-    
     console.log("loadImage " + filename);
     var img = new Image();
     img.src = filename;
@@ -3652,22 +3601,18 @@ Neo.Painter.prototype.loadImage = function (filename) {
     };
 };
 
-Neo.Painter.prototype.loadAnimation = function (filename, wait) {
+Neo.Painter.prototype.loadAnimation = function (filename) {
     console.log("loadAnimation " + filename);
-    var request = new XMLHttpRequest();
-    request.open("GET", filename, true);
-    request.responseType = "arraybuffer";
-    request.onload = function() {
-        var byteArray = new Uint8Array(request.response);
-        var header = byteArray.slice(0, 12);
-        console.log('header..', header);
-        var data = LZString.decompressFromUint8Array(byteArray.slice(12));
-        console.log('body...', data);
-        data = JSON.parse(data);
-        Neo.painter._actionMgr._items = data;
-        Neo.painter._actionMgr.play(wait);
-    };
-    request.send();
+
+    Neo.painter.busy = true;
+    Neo.painter.busySkipped = false;
+    
+    Neo.getPCH(filename, function(pch) {
+        //console.log(pch);
+        Neo.painter._actionMgr._items = pch.data;
+        Neo.painter._actionMgr._mark = pch.data.length;
+        Neo.painter._actionMgr.play();
+    });
 };
 
 Neo.Painter.prototype.loadSession = function (callback) {
@@ -3791,28 +3736,64 @@ Neo.Painter.prototype.getEmulationMode = function() {
 */
 
 Neo.Painter.prototype.play = function(wait) {
-    this.saveSnapshot();
-
     if (this._actionMgr) {
         this._actionMgr.clearCanvas();
-        this._actionMgr._head = 0;
         this.prevLine = null;
 
+        //console.log('[play]');
+        
+        this._actionMgr._head = 0;
+        this._actionMgr._index = 0;
+        this._actionMgr._mark = this._actionMgr._items.length;
+        this._actionMgr._pause = false;
         this._actionMgr.play(wait);
     }
 };
 
-Neo.Painter.prototype.snapshot = [];
-Neo.Painter.prototype.saveSnapshot = function() {
-    var width = this.canvasWidth;
-    var height = this.canvasHeight;
-    this.snapshot = [this.canvasCtx[0].getImageData(0, 0, width, height),
-                     this.canvasCtx[1].getImageData(0, 0, width, height)];
+Neo.Painter.prototype.onrewind = function() {
+    if (this._actionMgr) {
+        this._actionMgr.clearCanvas();
+        this._actionMgr._head = 0;
+        this._actionMgr._index = 0;
+        this.prevLine = null;
+     }
+    if (Neo.viewerBar) Neo.viewerBar.update();
+    if (!this._actionMgr._pause) {
+        this._actionMgr.play();
+    }
 };
 
-Neo.Painter.prototype.loadSnapshot = function() {
-    this.canvasCtx[0].putImageData(this.snapshot[0], 0, 0);
-    this.canvasCtx[1].putImageData(this.snapshot[1], 0, 0);
+Neo.Painter.prototype.onmark = function() {
+    if (Neo.viewerBar) Neo.viewerBar.update();
+    if (!this._actionMgr._pause) {
+        if (this._actionMgr._head > this._actionMgr._mark) {
+            this.onrewind();
+        } else {
+            this.onplay();
+        }
+    }
+};
+
+Neo.Painter.prototype.onplay = function() {
+    Neo.viewerPlay.setSelected(true);
+    Neo.viewerStop.setSelected(false);
+
+    this._actionMgr._pause = false;
+    this._actionMgr.play();
+};
+
+Neo.Painter.prototype.onstop = function() {
+    Neo.viewerPlay.setSelected(false);
+    Neo.viewerStop.setSelected(true);
+    this._actionMgr._pause = true;
+};
+
+Neo.Painter.prototype.onspeed = function() {
+    var mgr = Neo.painter._actionMgr;
+    var mode = (mgr._speedMode + 1) % 4;
+    mgr._speedMode = mode;
+    mgr._speed = mgr._speedTable[mode];
+//  console.log('speed=', mgr._speed);
 };
 
 Neo.Painter.prototype.setCurrent = function(item) {
@@ -4212,7 +4193,8 @@ Neo.DrawToolBase.prototype.bezierDownHandler = function(oe) {
 Neo.DrawToolBase.prototype.bezierUpHandler = function(oe) {
     if (this.isUpMove == false) {
         this.isUpMove = true;
-    }
+
+    } else return; // 枠外からベジェを開始したときdownを通らずにupが呼ばれてエラーになる
 
     this.step++;
     switch (this.step) {
@@ -4766,7 +4748,7 @@ Neo.EraseRectTool.prototype.doEffect = function(oe, x, y, width, height) {
 //  var ctx = oe.canvasCtx[oe.current];
 //  oe.eraseRect(ctx, x, y, width, height);
 //  oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
-    oe._actionMgr.eraseRect(x, y, width, height);
+    oe._actionMgr.eraseRect2(x, y, width, height);
 };
 
 /*
@@ -4942,6 +4924,12 @@ Neo.PasteTool.prototype.keyDownHandler = function(e) {
         oe.setToolByType(Neo.Painter.TOOLTYPE_COPY);
     }
 };
+
+Neo.PasteTool.prototype.kill = function() {
+    var oe = Neo.painter;
+    oe.tempCanvasCtx.clearRect(0, 0, oe.canvasWidth, oe.canvasHeight);
+};
+    
 
 Neo.PasteTool.prototype.drawCursor = function(oe) {
     var ctx = oe.destCanvasCtx;
@@ -5240,10 +5228,46 @@ Neo.CopyrightCommand.prototype.execute = function() {
 'use strict';
 
 
+/*
+  -----------------------------------------------------------------------
+    Action Manager
+  -----------------------------------------------------------------------
+*/
+
 Neo.ActionManager = function() {
     this._items = [];
     this._head = 0;
-}
+    this._index = 0;
+    
+    this._pause = false;
+    this._mark = 0;
+
+    this._speedTable = [-1, 0, 1, 11];
+    this._speed = parseInt(Neo.config.speed || 0);
+    this._speedMode = this.generateSpeedTable();
+
+    this._prevSpeed = this._speed; // freeHandの途中で速度が変わると困るので
+};
+
+Neo.ActionManager.prototype.generateSpeedTable = function() {
+    var speed = this._speed;
+    var mode = 0;
+
+    if (speed < 0) {
+        mode = 0;
+
+    } else if (speed == 0) {
+        mode = 1;
+        
+    } else if (speed <= 10) {
+        mode = 2;
+
+    } else {
+        mode = 3;
+    }
+    this._speedTable[mode] = speed;
+    return mode;
+};
 
 Neo.ActionManager.prototype.step = function() {
     if (!Neo.animation) return;
@@ -5253,7 +5277,8 @@ Neo.ActionManager.prototype.step = function() {
     }
     this._items.push([]);
     this._head++;
-}
+    this._index = 0;
+};
 
 Neo.ActionManager.prototype.back = function() {
     if (!Neo.animation) return;
@@ -5261,7 +5286,7 @@ Neo.ActionManager.prototype.back = function() {
     if (this._head > 0) {
         this._head--;
     }
-}
+};
 
 Neo.ActionManager.prototype.forward = function() {
     if (!Neo.animation) return;
@@ -5269,7 +5294,7 @@ Neo.ActionManager.prototype.forward = function() {
     if (this._head < this._items.length) {
         this._head++;
     }
-}
+};
 
 Neo.ActionManager.prototype.push = function() {
     if (!Neo.animation) return;
@@ -5306,10 +5331,27 @@ Neo.ActionManager.prototype.getCurrent = function(item) {
     oe._currentMaskType = item[10];
 };
 
+Neo.ActionManager.prototype.skip = function(wait) {
+    for (var i = 0; i < this._items.length; i++) {
+        if (this._items[i][0] == 'restore') {
+            this._head = i;
+        }
+    }
+};
+
 Neo.ActionManager.prototype.play = function(wait) {
-    if (!wait) wait = 0;
+    if (!wait) {
+        wait = (this._prevSpeed < 0) ? 0 : this._prevSpeed;
+        wait *= 1; //2
+    }
+    if (Neo.viewerBar) Neo.viewerBar.update();
     
-    if (this._head < this._items.length) {
+    if (this._pause) {
+        console.log('suspend viewer');
+        return;
+    }
+
+    if ((this._head < this._items.length) && (this._head < this._mark)) {
         var item = this._items[this._head];
 
         if (!Neo.viewer) {
@@ -5319,34 +5361,49 @@ Neo.ActionManager.prototype.play = function(wait) {
                                   true);
         }
 
-        console.log("play", item[0], this._head, this._items.length);
-
-        if (item[0] != "restore") {
-            // sync
-            if (item[0] && this[item[0]]) {
-                (this[item[0]])(item);
-            }
-            this._head++;
-
-            setTimeout(function() {
-                Neo.painter._actionMgr.play(wait);
-            }, wait);
-
-        } else {
-            // async
-            if (item[0] && this[item[0]]) {
-                (this[item[0]])(item, function() {
-                    Neo.painter._actionMgr.play(wait);
-                });
-            }
-            this._head++;
+        if (Neo.viewer && Neo.viewerBar) {
+            console.log("play", item[0], this._head + 1, this._items.length);
         }
+
+        var that = this;
+        var func = (item[0] && this[item[0]]) ? item[0] : 'dummy';
+
+        (this[func])(item, function(result) {
+            if (result) {
+                if (Neo.painter.busySkipped &&
+                    that._head < that._mark - 2 && that._mark - 2 >= 0 &&
+                    that._items[that._mark - 1][0] == 'restore') {
+                    that._head = that._mark - 2;
+
+                } else {
+                    that._head++;
+                }
+                that._index = 0;
+                that._prevSpeed = that._speed;
+            }
+
+            if ((that._prevSpeed < 0) && (that._head % 10 != 0)) {
+                Neo.painter._actionMgr.play();
+
+            } else {
+                setTimeout(function () {
+                    Neo.painter._actionMgr.play();
+                }, wait);
+            }
+        });
 
     } else {
         Neo.painter.dirty = false;
+        Neo.painter.busy = false;
+
+        if (Neo.painter.bushSkipped) {
+            Neo.painter.busySkipped = false;
+            console.log('animation skipped');
+        } else {
+            console.log('animation finished');
+        }
     }
 }
-
 
 /*
 -------------------------------------------------------------------------
@@ -5363,6 +5420,9 @@ Neo.ActionManager.prototype.clearCanvas = function() {
     oe.canvasCtx[0].clearRect(0, 0, oe.canvasWidth, oe.canvasHeight);
     oe.canvasCtx[1].clearRect(0, 0, oe.canvasWidth, oe.canvasHeight);
     oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.floodFill = function(layer, x, y, color) {
@@ -5380,30 +5440,86 @@ Neo.ActionManager.prototype.floodFill = function(layer, x, y, color) {
     var oe = Neo.painter;
     oe.doFloodFill(layer, x, y, color);
     oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.eraseAll = function() {
     var oe = Neo.painter;
     var layer = oe.current;
     
-    if (typeof layer != "object") {
+    if (typeof arguments[0] != "object") {
         this.push('eraseAll', layer);
 
     } else {
-        var item = layer;
+        var item = arguments[0];
         layer = item[1];
     }
 
     var oe = Neo.painter;
     oe.canvasCtx[layer].clearRect(0, 0, oe.canvasWidth, oe.canvasHeight);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.freeHand = function(x0, y0, lineType) {
     var oe = Neo.painter;
     var layer = oe.current;
-    
-    if (arguments.length > 1) {
+
+    if (typeof arguments[0] != "object") {
+        this.push('freeHand', layer);
+        this.pushCurrent();
+        this.push(lineType, x0, y0, x0, y0);
+        
+        oe.drawLine(oe.canvasCtx[layer], x0, y0, x0, y0, lineType);
+
+    } else if (!Neo.viewer || this._prevSpeed <= 0) {
+        this.freeHandFast(arguments[0], arguments[1]);
+        
+    } else {
+        var item = arguments[0];
+
+        layer = item[1];
+        lineType = item[11];
+        this.getCurrent(item);
+
+        var i = this._index;
+        if (i == 0) {
+            i = 12;
+        } else {
+            i += 2;
+        }
+
+        var x1 = item[i + 0];
+        var y1 = item[i + 1];
+        x0 = item[i + 2];
+        y0 = item[i + 3];
+
+        oe.drawLine(oe.canvasCtx[layer], x0, y0, x1, y1, lineType);
+        oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+        this._index = i;
+        var result = (i + 2 + 3) >= item.length;
+ 
+        if (!result) {
+            oe.prevLine = null;
+        }
+        
+        var callback = arguments[1];
+        if (callback && typeof callback == "function") {
+            callback(result);
+        }
+    }
+}
+
+Neo.ActionManager.prototype.freeHandFast = function(x0, y0, lineType) {
+    var oe = Neo.painter;
+    var layer = oe.current;
+
+    if (typeof arguments[0] != "object") {
         this.push('freeHand', layer);
         this.pushCurrent();
         this.push(lineType, x0, y0, x0, y0);
@@ -5430,8 +5546,11 @@ Neo.ActionManager.prototype.freeHand = function(x0, y0, lineType) {
             oe.drawLine(oe.canvasCtx[layer], x0, y0, x1, y1, lineType);
         }
         oe.prevLine = null;
-        oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+        oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
     }
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.freeHandMove = function(x0, y0, x1, y1, lineType) {
@@ -5471,7 +5590,7 @@ Neo.ActionManager.prototype.line = function(
     var oe = Neo.painter;
     var layer = oe.current;
 
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('line', layer);
         this.pushCurrent();
         this.push(lineType, x0, y0, x1, y1);
@@ -5489,7 +5608,10 @@ Neo.ActionManager.prototype.line = function(
         y1 = item[15];
     }
     oe.drawLine(oe.canvasCtx[layer], x0, y0, x1, y1, lineType);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.bezier = function(
@@ -5501,11 +5623,13 @@ Neo.ActionManager.prototype.bezier = function(
 {
     var oe = Neo.painter;
     var layer = oe.current;
-
-    if (arguments.length > 1) {
+    var isReplay = true;
+    
+    if (typeof arguments[0] != "object") {
         this.push('bezier', layer)
         this.pushCurrent();
         this.push(lineType, x0, y0, x1, y1, x2, y2, x3, y3);
+        isReplay = false;
         
     } else {
         var item = arguments[0];
@@ -5522,15 +5646,18 @@ Neo.ActionManager.prototype.bezier = function(
         x3 = item[18];
         y3 = item[19];
     }
-    oe.drawBezier(oe.canvasCtx[layer], x0, y0, x1, y1, x2, y2, x3, y3, lineType);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.drawBezier(oe.canvasCtx[layer], x0, y0, x1, y1, x2, y2, x3, y3, lineType, isReplay);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.fill = function(x, y, width, height, type) {
     var oe = Neo.painter;
     var layer = oe.current;
 
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('fill', layer);
         this.pushCurrent();
         this.push(x, y, width, height, type);
@@ -5546,15 +5673,19 @@ Neo.ActionManager.prototype.fill = function(x, y, width, height, type) {
         height = item[14];
         type = item[15];
     }
+
     oe.doFill(layer, x, y, width, height, type);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.flipH = function(x, y, width, height) {
     var oe = Neo.painter;
     var layer = oe.current;
 
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('flipH', layer, x, y, width, height);
         
     } else {
@@ -5566,14 +5697,17 @@ Neo.ActionManager.prototype.flipH = function(x, y, width, height) {
         height = item[5];
     }
     oe.flipH(layer, x, y, width, height);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.flipV = function(x, y, width, height) {
     var oe = Neo.painter;
     var layer = oe.current;
     
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('flipV', layer, x, y, width, height);
         
     } else {
@@ -5585,14 +5719,17 @@ Neo.ActionManager.prototype.flipV = function(x, y, width, height) {
         height = item[5];
     }
     oe.flipV(layer, x, y, width, height);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.merge = function(x, y, width, height) {
     var oe = Neo.painter;
     var layer = oe.current;
 
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('merge', layer, x, y, width, height);
         
     } else {
@@ -5604,14 +5741,18 @@ Neo.ActionManager.prototype.merge = function(x, y, width, height) {
         height = item[5];
     }
     oe.merge(layer, x, y, width, height);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.blurRect = function(x, y, width, height) {
     var oe = Neo.painter;
     var layer = oe.current;
 
-    if (arguments.length > 1) {
+
+    if (typeof arguments[0] != "object") {
         this.push('blurRect', layer, x, y, width, height);
         
     } else {
@@ -5623,14 +5764,43 @@ Neo.ActionManager.prototype.blurRect = function(x, y, width, height) {
         height = item[5];
     }
     oe.blurRect(layer, x, y, width, height);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
+}
+
+Neo.ActionManager.prototype.eraseRect2 = function(x, y, width, height) {
+    var oe = Neo.painter;
+    var layer = oe.current;
+
+    if (typeof arguments[0] != "object") {
+        this.push('eraseRect2', layer);
+        this.pushCurrent();
+        this.push(x, y, width, height);
+        
+    } else {
+        var item = arguments[0];
+        layer = item[1];
+        this.getCurrent(item);
+        
+        x = item[11];
+        y = item[12];
+        width = item[13];
+        height = item[14];
+    }
+    oe.eraseRect(layer, x, y, width, height);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.eraseRect = function(x, y, width, height) {
     var oe = Neo.painter;
     var layer = oe.current;
 
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('eraseRect', layer, x, y, width, height);
         
     } else {
@@ -5642,14 +5812,17 @@ Neo.ActionManager.prototype.eraseRect = function(x, y, width, height) {
         height = item[5];
     }
     oe.eraseRect(layer, x, y, width, height);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.copy = function(x, y, width, height) {
     var oe = Neo.painter;
     var layer = oe.current;
 
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('copy', layer, x, y, width, height);
         
     } else {
@@ -5667,13 +5840,16 @@ Neo.ActionManager.prototype.copy = function(x, y, width, height) {
     oe.tool.width = width;
     oe.tool.height = height;
 //  oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.paste = function(x, y, width, height, dx, dy) {
     var oe = Neo.painter;
     var layer = oe.current;
 
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('paste', layer, x, y, width, height, dx, dy);
         
     } else {
@@ -5688,14 +5864,17 @@ Neo.ActionManager.prototype.paste = function(x, y, width, height, dx, dy) {
     }
 
     oe.paste(layer, x, y, width, height, dx, dy);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.turn = function(x, y, width, height) {
     var oe = Neo.painter;
     var layer = oe.current;
 
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('turn', layer, x, y, width, height);
         
     } else {
@@ -5707,7 +5886,10 @@ Neo.ActionManager.prototype.turn = function(x, y, width, height) {
         height = item[5];
     }
     oe.turn(layer, x, y, width, height);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.text = function(
@@ -5721,7 +5903,7 @@ Neo.ActionManager.prototype.text = function(
     var oe = Neo.painter;
     var layer = oe.current;
     
-    if (arguments.length > 1) {
+    if (typeof arguments[0] != "object") {
         this.push('text', layer, x, y, color, alpha, string, size, family);
 
     } else {
@@ -5737,7 +5919,10 @@ Neo.ActionManager.prototype.text = function(
         family = item[8];
     }
     oe.doText(layer, x, y, color, alpha, string, size, family);
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
+
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
 }
 
 Neo.ActionManager.prototype.restore = function() {
@@ -5745,7 +5930,7 @@ Neo.ActionManager.prototype.restore = function() {
     var width = oe.canvasWidth;
     var height = oe.canvasHeight;
     
-    if (arguments.length == 0) {
+    if (typeof arguments[0] != "object") {
         this.push('restore');
 
         var img0 = oe.canvas[0].toDataURL('image/png');
@@ -5768,11 +5953,297 @@ Neo.ActionManager.prototype.restore = function() {
                 oe.canvasCtx[1].drawImage(img1, 0, 0);
                 oe.updateDestCanvas(0, 0, width, height);
 
-                if (callback) callback();
+                if (callback && typeof callback == "function") callback(true);
             }
         }
     }
 }
+
+Neo.ActionManager.prototype.dummy = function() {
+    var callback = arguments[1];
+    if (callback && typeof callback == "function") callback(true);
+}
+
+/*
+  -----------------------------------------------------------------------
+    動画表示モード
+  -----------------------------------------------------------------------
+*/
+
+Neo.createViewer = function(applet) {
+    var neo = document.createElement("div");
+    neo.className = "NEO";
+    neo.id = "NEO";
+    var html = (function() {/*
+<script src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
+
+<div id="pageView" style="margin:auto;">
+<div id="container" style="visibility:visible;" class="o">
+
+<div id="painter" style="background-color:white;">
+<div id="canvas" style="background-color:white;">
+</div>
+</div>
+
+
+<div id="viewerButtonsWrapper" style="display:block;">
+<div id="viewerButtons" style="display:block;">
+
+<div id="viewerPlay"></div>
+<div id="viewerStop"></div>
+<div id="viewerRewind"></div>
+<div id="viewerSpeed" style="padding-left:2px; margin-top: 1px;">ほ</div>
+<div id="viewerPlus"></div>
+<div id="viewerMinus"></div>
+
+<div id="viewerBar" style="display:inline-block;">
+<!--
+  <div id="viewerBarLeft" style="width:calc(50% - 2px); height:16px; position: absolute; top: 1px; left: 1px;"></div>
+  <div id="viewerBarMark" style="background-color:red; width:1px; height:16px; position:absolute; top:1px; left:1px;"></div>
+-->
+</div>
+</div>
+
+</div>
+</div>
+                                 */}).toString().match(/\/\*([^]*)\*\//)[1];
+
+    neo.innerHTML = html.replace(/\[(.*?)\]/g, function(match, str) {
+	return Neo.translate(str)
+    })
+    
+    var parent = applet.parentNode;
+    parent.appendChild(neo);
+    parent.insertBefore(neo, applet);
+
+    // applet.style.display = "none";
+
+    // NEOを組み込んだURLをアプリ版で開くとDOMツリーが2重にできて格好悪いので消しておく
+    setTimeout(function() {
+        var tmp = document.getElementsByClassName("NEO");
+        if (tmp.length > 1) {
+            for (var i = 1; i < tmp.length; i++) {
+                tmp[i].style.display = "none";
+            }
+        }
+    }, 0);
+};
+
+Neo.initViewer = function(pch) {
+    var pageview = document.getElementById("pageView");
+    var pageWidth = Neo.config.applet_width;
+    var pageHeight = Neo.config.applet_height;
+    pageview.style.width = pageWidth + "px";
+    pageview.style.height = pageHeight + "px";
+    
+    Neo.canvas = document.getElementById("canvas");
+    Neo.container = document.getElementById("container");
+    Neo.container.style.backgroundColor = Neo.config.color_back;
+    Neo.container.style.border = "0";
+
+    var dx = (pageWidth - Neo.config.width) / 2;
+    var dy = (pageHeight - Neo.config.height - 26) / 2;
+    
+    var painter = document.getElementById("painter");
+
+    painter.style.marginTop = "0";
+    painter.style.position = "absolute";
+    painter.style.padding = "0";
+    painter.style.bottom = (dy + 26) + "px";
+    painter.style.left = (dx) + "px";
+
+    var viewerButtonsWrapper = document.getElementById("viewerButtonsWrapper");
+    viewerButtonsWrapper.style.width = (pageWidth - 2) + "px";
+    
+    var viewerBar = document.getElementById("viewerBar");
+    viewerBar.style.position = "absolute";
+    viewerBar.style.right = "2px";
+    viewerBar.style.top = "1px";
+    viewerBar.style.width = (pageWidth - (24 * 6) - 2) + "px"; 
+    
+    Neo.canvas.style.width = Neo.config.width + "px";
+    Neo.canvas.style.height = Neo.config.height + "px";
+    
+    Neo.painter = new Neo.Painter();
+    Neo.painter.build(Neo.canvas, Neo.config.width, Neo.config.height);
+    
+    Neo.container.oncontextmenu = function() {return false;};
+
+    painter.addEventListener('mousedown', function() {
+        Neo.painter._actionMgr.isMouseDown = true;
+    }, false);
+    
+    document.addEventListener('mousemove', function(e) {
+        if (Neo.painter._actionMgr.isMouseDown) {
+            var zoom = Neo.painter.zoom;
+            var x = Neo.painter.zoomX - e.movementX / zoom;
+            var y = Neo.painter.zoomY - e.movementY / zoom;
+            Neo.painter.setZoomPosition(x, y);
+        }
+    }, false);
+    document.addEventListener('mouseup', function() {
+        Neo.painter._actionMgr.isMouseDown = false;
+        Neo.viewerBar.isMouseDown = false;
+    }, false);
+    
+    if (pch) {//Neo.config.pch_file) {
+        Neo.painter._actionMgr._items = pch.data;
+        Neo.painter.play();
+    }
+};
+
+Neo.startViewer = function() {
+    var name = Neo.applet.attributes.name.value || "pch";
+    if (!document[name]) document[name] = Neo;
+    Neo.applet.parentNode.removeChild(Neo.applet);
+
+    Neo.styleSheet = Neo.getStyleSheet();
+    var lightBack = Neo.multColor(Neo.config.color_back, 1.3);
+    var darkBack = Neo.multColor(Neo.config.color_back, 0.7);
+    
+    Neo.addRule(".NEO #viewerButtons", "color", Neo.config.color_text);
+    Neo.addRule(".NEO #viewerButtons", "background-color", Neo.config.color_back);
+
+    Neo.addRule(".NEO #viewerButtonsWrapper", "border", "1px solid " + Neo.config.color_frame + " !important");
+
+    Neo.addRule(".NEO #viewerButtons", "border", "1px solid " + Neo.config.color_back + " !important");
+    Neo.addRule(".NEO #viewerButtons", "border-left", "1px solid " + lightBack + " !important");
+    Neo.addRule(".NEO #viewerButtons", "border-top", "1px solid " + lightBack + " !important");
+
+    Neo.addRule(".NEO #viewerButtons >div.buttonOff", "background-color", Neo.config.color_icon + " !important");
+
+    Neo.addRule(".NEO #viewerButtons >div.buttonOff:active", "background-color", darkBack + " !important");
+    Neo.addRule(".NEO #viewerButtons >div.buttonOn", "background-color", darkBack + " !important");
+
+    Neo.addRule(".NEO #viewerButtons >div", "border", "1px solid " + Neo.config.color_frame + " !important");
+    
+    Neo.addRule(".NEO #viewerButtons >div.buttonOff:hover", "border", "1px solid" + Neo.config.color_bar_select + " !important");
+
+    Neo.addRule(".NEO #viewerButtons >div.buttonOff:active", "border", "1px solid" + Neo.config.color_bar_select + " !important");
+    Neo.addRule(".NEO #viewerButtons >div.buttonOn", "border", "1px solid" + Neo.config.color_bar_select + " !important");
+
+    Neo.addRule(".NEO #viewerBar >div", "background-color", Neo.config.color_bar);
+//  Neo.addRule(".NEO #viewerBar:active", "background-color", darkBack);
+    Neo.addRule(".NEO #viewerBarMark", "background-color", Neo.config.color_text + " !important");
+
+    setTimeout(function () {
+        Neo.viewerPlay = new Neo.ViewerButton().init("viewerPlay");
+        Neo.viewerPlay.setSelected(true);
+        Neo.viewerPlay.onmouseup = function() {
+            Neo.painter.onplay();
+        }
+        Neo.viewerStop = new Neo.ViewerButton().init("viewerStop");
+        Neo.viewerStop.onmouseup = function() {
+            Neo.painter.onstop();
+        }
+        
+        new Neo.ViewerButton().init("viewerRewind").onmouseup = function() {
+            Neo.painter.onrewind();
+        }
+        new Neo.ViewerButton().init("viewerSpeed").onmouseup = function() {
+            Neo.painter.onspeed();
+            this.update();
+        };
+        new Neo.ViewerButton().init("viewerPlus").onmouseup = function() {
+            new Neo.ZoomPlusCommand(Neo.painter).execute();
+        };
+        new Neo.ViewerButton().init("viewerMinus").onmouseup = function() {
+            new Neo.ZoomMinusCommand(Neo.painter).execute();
+        };
+
+        var length = Neo.painter._actionMgr._items.length;
+        Neo.viewerBar = new Neo.ViewerBar().init("viewerBar", { length:length });
+
+    }, 0);
+};
+
+Neo.getFilename = function() {
+    return Neo.config.pch_file || Neo.config.image_canvas;
+};
+
+Neo.getPCH = function(filename, callback) {
+    if (!filename || filename.slice(-4).toLowerCase() != ".pch") return null;
+    
+    var request = new XMLHttpRequest();
+    request.open("GET", filename, true);
+    request.responseType = "arraybuffer";
+    request.onload = function() {
+        var byteArray = new Uint8Array(request.response);
+//      var data = LZString.decompressFromUint8Array(byteArray.slice(12));
+//      var header = byteArray.slice(0, 12);
+        var data = LZString.decompressFromUint8Array(byteArray.subarray(12));
+        var header = byteArray.subarray(0, 12);
+
+        if ((header[0] == "N".charCodeAt(0)) &&
+            (header[1] == "E".charCodeAt(0)) &&
+            (header[2] == "O".charCodeAt(0))) {
+            var width = header[4] + header[5] * 0x100
+            var height = header[6] + header[7] * 0x100
+
+            //console.log('NEO animation:', width, 'x', height);
+            if (callback) {
+                var items = Neo.fixPCH(JSON.parse(data))
+                callback({
+                    width:width,
+                    height:height,
+                    data:items
+                });
+            }
+            
+        } else {
+            console.log('not a NEO animation:');
+        }
+    }
+    request.send();
+};
+
+Neo.fixPCH = function(items) {
+    for (var i = 0; i < items.length; i++) {
+        var item = items[i];
+
+        var index = item.indexOf('eraseAll');
+        if (index > 0) {
+            var tmp = item.slice(index);
+            var tmp2 = item.slice(0, index);
+            console.log("fix eraseAll", tmp2, tmp);
+
+            items[i] = tmp2;
+            items.splice(i, 0, tmp)
+        }
+    }
+    return items;
+};
+
+/*
+  -----------------------------------------------------------------------
+    LiveConnect
+  -----------------------------------------------------------------------
+*/
+
+Neo.playPCH = function() {
+    Neo.painter.onplay();
+};
+
+Neo.suspendDraw = function() {
+    Neo.painter.onstop();
+};
+
+Neo.setSpeed = function(value) {
+    Neo.painter._actionMgr._speed = value;
+};
+
+Neo.setMark = function(value) {
+    Neo.painter._actionMgr._mark = value;
+    Neo.painter.onmark();
+};
+
+Neo.getSeek = function() {
+    return Neo.painter._actionMgr._head;
+};
+
+Neo.getLineCount = function() {
+    return Neo.painter._actionMgr._items.length;
+};
 
 'use strict';
 
@@ -6159,31 +6630,14 @@ Neo.ToolTip.prototype.draw = function(c) {
             }.bind(this);
 
         } else {
-            this.tintImage(ctx, c);
+            Neo.tintImage(ctx, c);
         }
     }
 };
 
 Neo.ToolTip.prototype.drawTintImage = function(ctx, img, c, x, y) {
     ctx.drawImage(img, x, y);
-    this.tintImage(ctx, c);
-};
-
-Neo.ToolTip.prototype.tintImage = function(ctx, c) {
-    c = (Neo.painter.getColor(c) & 0xffffff);
-    
-    var imageData = ctx.getImageData(0, 0, 46, 18);
-    var buf32 = new Uint32Array(imageData.data.buffer);
-    var buf8 = new Uint8ClampedArray(imageData.data.buffer);
-
-    for (var i = 0; i < buf32.length; i++) {
-        var a = buf32[i] & 0xff000000;
-        if (a) {
-            buf32[i] = buf32[i] & a | c;
-        }
-    }
-    imageData.data.set(buf8);
-    ctx.putImageData(imageData, 0, 0);
+    Neo.tintImage(ctx, c);
 };
 
 Neo.ToolTip.bezier = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAATCAYAAADWOo4fAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QAAAAAAAD5Q7t/AAAACXBIWXMAAAsSAAALEgHS3X78AAAAT0lEQVRIx+3SQQoAIAhE0en+h7ZVEEKBZrX5b5sjKknAkRYpNslaMLPq44ZI9wwHs0vMQ/v87u0Kk8xfsaI242jbMdjPi5Y0r/zTAAAAD3UOjRf9jcO4sgAAAABJRU5ErkJggg==";
@@ -7039,6 +7493,133 @@ Neo.ScrollBarButton.prototype.update = function(oe) {
     }
 };
 
+/*
+  -------------------------------------------------------------------------
+    ViewerButton
+  -------------------------------------------------------------------------
+*/
+
+Neo.ViewerButton = function() {};
+Neo.ViewerButton.prototype = new Neo.Button();
+
+Neo.ViewerButton.speedStrings = ["最", "早", "既", "鈍"];
+
+Neo.ViewerButton.prototype.init = function(name, params) {
+    Neo.Button.prototype.init.call(this, name, params);
+
+    if (name != "viewerSpeed") {
+        this.element.innerHTML = "<canvas width=24 height=24></canvas>"
+        this.canvas = this.element.getElementsByTagName('canvas')[0];
+        var ctx = this.canvas.getContext("2d");
+        
+        var img = new Image();
+        img.src = Neo.ViewerButton[name.toLowerCase().replace(/viewer/, '')];
+        img.onload = function() {
+            var ref = this;
+            ctx.clearRect(0, 0, 24, 24);
+            ctx.drawImage(img, 0, 0);
+            Neo.tintImage(ctx, Neo.config.color_text)
+        }.bind(this);
+
+    } else {
+        this.element.innerHTML = "<div></div><canvas width=24 height=24></canvas>"
+        this.update();
+    }
+    return this;
+};
+
+Neo.ViewerButton.prototype.update = function() {
+    if (this.name == "viewerSpeed") {
+        var mode = Neo.painter._actionMgr._speedMode;
+        var speedString = Neo.translate(Neo.ViewerButton.speedStrings[mode]);
+        this.element.children[0].innerHTML = "<div>" + speedString + "</div>";
+    }
+};
+
+Neo.ViewerButton.minus = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQAQMAAAAlPW0iAAAABlBMVEX/////HgA/G9hMAAAAAXRSTlMAQObYZgAAABFJREFUCNdjYMAG5H+AEDYAADOnAi81ABEKAAAAAElFTkSuQmCC";
+
+Neo.ViewerButton.plus = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQAgMAAABinRfyAAAACVBMVEX/////HgD/HgAvnCBAAAAAAnRSTlMAAHaTzTgAAAAfSURBVAjXY2BAA0wTMAimVasaIARj2FQHCIGkBAUAAGm3CXHeKF1tAAAAAElFTkSuQmCC";
+
+Neo.ViewerButton.play = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQAgMAAABinRfyAAAACVBMVEX/////HgD/HgAvnCBAAAAAAnRSTlMAAHaTzTgAAAAuSURBVAjXY2BAABUQoQkitBxAxAQQsQRErAQRq+CspSBiKogIAekIABKqDhAzAAuwB6SsnxQ6AAAAAElFTkSuQmCC";
+
+Neo.ViewerButton.stop = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQAQMAAAAlPW0iAAAABlBMVEX/////HgA/G9hMAAAAAXRSTlMAQObYZgAAABFJREFUCNdjYIAB+x8EEBgAACjyDV75Mi9xAAAAAElFTkSuQmCC";
+
+Neo.ViewerButton.rewind = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQAQMAAAAlPW0iAAAABlBMVEX/////HgA/G9hMAAAAAXRSTlMAQObYZgAAACxJREFUCNdjYAADJiYGNjYGPj4GOTkGOzuGujqGf/9AJJANFAGKA2WBahgYAIE2Bb0RIYJRAAAAAElFTkSuQmCC";
+
+/*
+  -------------------------------------------------------------------------
+    ViewerBar
+  -------------------------------------------------------------------------
+*/
+
+// length/mark/count
+// update
+
+Neo.ViewerBar = function() {};
+Neo.ViewerBar.prototype.init = function(name, params) {
+    this.element = document.getElementById(name);
+    this.params = params || {};
+    this.name = name;
+    this.isMouseDown = false;
+
+    this.element.style.display = "inline-block";
+    this.element.innerHTML =
+        "<div id='viewerBarLeft'></div>" +
+        "<div id='viewerBarMark'></div>" +
+        "<div id='viewerBarText'>hoge</div>";
+    this.seekElement = this.element.children[0];
+    this.markElement = this.element.children[1];
+    this.textElement = this.element.children[2];
+
+    this.width = this.seekElement.offsetWidth;
+
+    this.length = this.params.length || 100;
+    this.mark = this.length;
+    this.seek = 0;
+
+    var ref = this;
+    this.element.onmousedown = function(e) {
+        ref.isMouseDown = true;
+        ref._touchHandler(e);
+    }
+    this.element.onmousemove = function(e) {
+        if (ref.isMouseDown) {
+            ref._touchHandler(e);
+        }
+    }
+//  this.element.onmouseup = function(e) { this.isMouseDown = false; }
+//  this.element.onmouseout = function(e) { this.isMouseDown = false; }
+    this.element.addEventListener("touchstart", function(e) {
+        ref._touchHandler(e);
+        e.preventDefault();
+    }, true);
+
+    this.update();
+    return this;
+};
+
+Neo.ViewerBar.prototype.update = function() {
+    this.mark = Neo.painter._actionMgr._mark;
+    this.seek = Neo.painter._actionMgr._head;
+    
+    var markX = (this.mark / this.length) * this.width;
+    this.markElement.style.left = markX + "px";
+
+    var seekX = (this.seek / this.length) * this.width;
+    this.seekElement.style.width = seekX + "px";
+    this.textElement.innerHTML = this.seek + '/' + this.length;
+};
+
+Neo.ViewerBar.prototype._touchHandler = function(e) {
+    var x = e.offsetX / this.width;
+    x = Math.max(Math.min(x, 1), 0);
+
+    Neo.painter._actionMgr._mark = Math.round(x * this.length);
+    //this.update();
+    //  console.log('mark=', this.mark, 'head=', Neo.painter._actionMgr._head);
+
+    Neo.painter.onmark();
+};
 
 // Copyright (c) 2013 Pieroxy <pieroxy@pieroxy.net>
 // This work is free. You can redistribute it and/or modify it

--- a/potiboard/potiboard.php
+++ b/potiboard/potiboard.php
@@ -1,7 +1,7 @@
 <?php
 /*
   *
-  * POTI-board改 v1.51.5 lot.190522
+  * POTI-board改 v1.51.6 lot.190528
   *   (C)sakots >> https://sakots.red/poti/
   *
   *----------------------------------------------------------------------------------
@@ -77,7 +77,7 @@ $picfile = ( isset( $_POST["picfile"]) === true ) ? newstring($_POST["picfile"])
 $del = ( isset($_POST["del"]) === true ) ? ($_POST["del"]): "";
 if(is_array($del)){
 	$countdel=count($del);
-	for($i = 0; $i < $countdel; $i++){
+	for($i = 0; $i < $countdel; ++$i){
 		if(!ctype_digit($del[$i])){//数字のみ
 		$del="";
 		}
@@ -118,7 +118,7 @@ if(isset($_GET["mode"])&&$_GET["mode"]==="edit"){
 		$del = ( isset($_GET["del"]) === true ) ? ($_GET["del"]): "";
 		if(is_array($del)){
 		$countdel=count($del);
-		for($i = 0; $i < $countdel; $i++){
+		for($i = 0; $i < $countdel; ++$i){
 		if(!ctype_digit($del[$i])){//数字のみ
 		$del="";
 		}
@@ -204,8 +204,8 @@ if((THUMB_SELECT==0 && gd_check()) || THUMB_SELECT==1){
 define('USE_MB' , '1');
 
 //バージョン
-define('POTI_VER' , '改 v1.51.5');
-define('POTI_VERLOT' , '改 v1.51.5 lot.190522');
+define('POTI_VER' , '改 v1.51.6');
+define('POTI_VERLOT' , '改 v1.51.6 lot.190528');
 
 //メール通知クラスのファイル名
 define('NOTICEMAIL_FILE' , 'noticemail.inc');
@@ -509,7 +509,7 @@ function updatelog($resno=0){
 	$find = false;
 	if($resno){
 		$counttree=count($tree);
-		for($i = 0;$i<$counttree;$i++){
+		for($i = 0;$i<$counttree;++$i){
 			list($artno,)=explode(",",rtrim($tree[$i]));
 			if($artno==$resno){$st=$i;$find=true;break;} //レス先検索
 		}
@@ -517,7 +517,7 @@ function updatelog($resno=0){
 	}
 	$line = file(LOGFILE);
 	$countline=count($line);
-	for($i = 0; $i < $countline; $i++){
+	for($i = 0; $i < $countline; ++$i){
 		list($no,) = explode(",", $line[$i]);
 		$lineindex[$no]=$i + 1; //逆変換テーブル作成
 	}
@@ -530,7 +530,7 @@ function updatelog($resno=0){
 		if(!$resno){
 			$st = $page;
 		}
-		for($i = $st; $i < $st+PAGE_DEF; $i++){
+		for($i = $st; $i < $st+PAGE_DEF; ++$i){
 //			if($tree[$i]=="") continue;
 			if(isset($tree[$i])){//未定義エラー対策
 			}else{continue;} 
@@ -885,8 +885,12 @@ function updatelog($resno=0){
 
 /* オートリンク */
 function auto_link($proto){
+	if(!preg_match("/script/",$proto)){//scriptがなければ続行
 	$proto = preg_replace("{(https?|ftp|news)(://[[:alnum:]\+\$\;\?\.%,!#~*/:@&=_-]+)}","<a href=\"\\1\\2\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">\\1\\2</a>",$proto);
 	return $proto;
+	}else{
+	return $proto;
+	}
 }
 
 /* 日付 */
@@ -1012,9 +1016,8 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 	// フォーム内容をチェック
 	if(!$name||preg_match("/^[ |　|]*$/",$name)) $name="";
 	if(!$com||preg_match("/^[ |　|\t]*$/",$com)) $com="";
-	if(!$sub||preg_match("/^[ |　|]*$/",$sub))   $sub="";
-	if(!$url||!preg_match("/^ *?https?:\/\//",$url))   $url="";
-
+	if(!$sub||preg_match("/^[ |　|]*$/",$sub)) $sub="";
+	if(!$url||!preg_match("/^ *?https?:\/\//",$url)||preg_match("/&lt;|</",$url)) $url="" ;
 	if(!$resto&&!$textonly&&!is_file($dest)) error(MSG007,$dest);
 	if(RES_UPLOAD&&$resto&&!$textonly&&!is_file($dest)) error(MSG007,$dest);
 
@@ -1150,7 +1153,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 	$buf = charconvert($buf,4);
 	$line = explode("\n",$buf);
 	$countline=count($line);
-	for($i = 0; $i < $countline; $i++){
+	for($i = 0; $i < $countline; ++$i){
 		if($line[$i]!=""){
 			list($artno,)=explode(",", rtrim($line[$i]));	//逆変換テーブル作成
 			$lineindex[$artno]=$i+1;
@@ -1165,8 +1168,8 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 	else{
 	$chkline=$countline-1;
 	}
-//	for($i=0;$i<20;$i++){ 
-	for($i=0;$i<$chkline;$i++){
+//	for($i=0;$i<20;++$i){ 
+	for($i=0;$i<$chkline;++$i){
 		list($lastno,,$lname,$lemail,$lsub,$lcom,$lurl,$lhost,$lpwd,,,,$ltime,) = explode(",", $line[$i]);
 		$pchk=0;
 		switch(POST_CHECKLEVEL){
@@ -1256,8 +1259,8 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 	$chkline=$countline-1;
 	}
 	if($dest&&file_exists($dest)){
-//		for($i=0;$i<200;$i++){ //画像重複チェック
-		for($i=0;$i<$chkline;$i++){ //画像重複チェック
+//		for($i=0;$i<200;++$i){ //画像重複チェック
+		for($i=0;$i<$chkline;++$i){ //画像重複チェック
 			list(,,,,,,,,,$extp,,,$timep,$chkp,) = explode(",", $line[$i]);
 			if($chkp==$chk&&file_exists($path.$timep.$extp)){
 				error(MSG005,$dest);
@@ -1290,7 +1293,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 	if($buf==''){error(MSG023,$dest);}
 	$line = explode("\n",$buf);
 	$countline=count($line);
-	for($i = 0; $i < $countline; $i++){
+	for($i = 0; $i < $countline; ++$i){
 		if($line[$i]!=""){
 			$line[$i].="\n";
 			$j=explode(",", rtrim($line[$i]));
@@ -1298,7 +1301,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 				$line[$i]='';
 	}	}	}
 	if($resto){
-		for($i = 0; $i < $countline; $i++){
+		for($i = 0; $i < $countline; ++$i){
 			$rtno = explode(",", rtrim($line[$i]));
 			if($rtno[0]==$resto){
 				$find = TRUE;
@@ -1400,11 +1403,11 @@ if(defined('URL_PARAMETER') && URL_PARAMETER){
 	}else{
 		$urlparameter = "";
 }
-	$str = "<!DOCTYPE html>\n<html lang=\"ja\"><head><meta http-equiv=\"refresh\" content=\"1;URL=".PHP_SELF2.$urlparameter."\">\n";
+	$str = "<!DOCTYPE html>\n<html lang=\"ja\"><head><meta http-equiv=\"refresh\" content=\"1; URL=".PHP_SELF2.$urlparameter."\">\n";
 	
 	$str.= "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1.0,minimum-scale=1.0\">\n<meta charset=\"".CHARSET_HTML."\"></head>\n";
 	if(!isset($mes)){$mes="";}
-	$str.= "<body>$mes 画面を切り替えます</body></html>";
+	$str.= "<body>".$mes." 画面を切り替えます</body></html>";
 	echo charconvert($str,4);
 }
 
@@ -1435,8 +1438,8 @@ function treedel($delno){
 	$line = explode("\n",$buf);
 	$countline=count($line);
 	$find=false;
-	for($i = 0; $i < $countline; $i++){if($line[$i]!=""){$line[$i].="\n";}}
-	for($i = 0; $i < $countline; $i++){
+	for($i = 0; $i < $countline; ++$i){if($line[$i]!=""){$line[$i].="\n";}}
+	for($i = 0; $i < $countline; ++$i){
 		$treeline = explode(",", rtrim($line[$i]));
 		$counttreeline=count($treeline);
 		for($j = 0; $j < $counttreeline; $j++){
@@ -1499,10 +1502,10 @@ function usrdel($del,$pwd){
 		$buf = charconvert($buf,4);
 		$line = explode("\n",$buf);
 		$countline=count($line);
-		for($i = 0; $i < $countline; $i++){if($line[$i]!==""){$line[$i].="\n";}}
+		for($i = 0; $i < $countline; ++$i){if($line[$i]!==""){$line[$i].="\n";}}
 		$flag = false;
 		$find = false;
-		for($i = 0; $i < $countline; $i++){
+		for($i = 0; $i < $countline; ++$i){
 		if($line[$i]){
 			list($no,,,,,,,$dhost,$pass,$ext,,,$tim,,) = explode(",",$line[$i]);
 			
@@ -1562,9 +1565,9 @@ function admindel($pass){
 		$buf = charconvert($buf,4);
 		$line = explode("\n",$buf);
 		$countline=count($line);
-		for($i = 0; $i < $countline; $i++){if($line[$i]!=""){$line[$i].="\n";}}
+		for($i = 0; $i < $countline; ++$i){if($line[$i]!=""){$line[$i].="\n";}}
 		$find = false;
-		for($i = 0; $i < $countline; $i++){
+		for($i = 0; $i < $countline; ++$i){
 		if($line[$i]){
 			list($no,,,,,,,,,$ext,,,$tim,,) = explode(",",$line[$i]);
 			if(in_array($no,$del)){
@@ -1824,7 +1827,7 @@ if(isset($savejpeg)){
 		$dat['anime'] = false;
 		$dat['imgfile'] = './'.PCH_DIR.$pch.$ext;
 	}
-	if(ADMIN_NEWPOST&&$admin==ADMIN_PASS) $dat['admin'] = 'picpost';
+	if(ADMIN_NEWPOST&&$admin===ADMIN_PASS) $dat['admin'] = 'picpost';
 
 	if(isset($C_Palette)){
 		for ($n = 1;$n < 7;++$n)
@@ -2095,9 +2098,9 @@ function editform($del,$pwd){
 		$buf = charconvert($buf,4);
 		$line = explode("\n",$buf);
 		$countline=count($line);
-		for($i = 0; $i < $countline; $i++){if($line[$i]!=""){$line[$i].="\n";}}
+		for($i = 0; $i < $countline; ++$i){if($line[$i]!=""){$line[$i].="\n";}}
 		$flag = FALSE;
-		for($i = 0; $i < $countline; $i++){
+		for($i = 0; $i < $countline; ++$i){
 		if($line[$i]){
 			list($no,,$name,$email,$sub,$com,$url,$ehost,$pass,,,,,,,$fcolor) = explode(",", rtrim($line[$i]));
 			if($no == $del[0] && (substr(md5($pwd),2,8) == $pass /*|| $ehost == $host*/ || ADMIN_PASS == $pwd)){
@@ -2278,12 +2281,12 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 	$buf = charconvert($buf,4);
 	$line = explode("\n",$buf);
 	$countline=count($line);
-	for($i = 0; $i < $countline; $i++){if($line[$i]!=""){$line[$i].="\n";}}
+	for($i = 0; $i < $countline; ++$i){if($line[$i]!=""){$line[$i].="\n";}}
 
 	// 記事上書き
 	$flag = FALSE;
 	$countline=count($line);
-	for($i = 0; $i<$countline; $i++){
+	for($i = 0; $i<$countline; ++$i){
 		list($eno,,$ename,,$esub,$ecom,$eurl,$ehost,$epwd,$ext,$W,$H,$tim,$chk,$ptime,$efcolor) = explode(",", rtrim($line[$i]));
 		if($eno == $no && ($pass == $epwd /*|| $ehost == $host*/ || ADMIN_PASS == $admin)){
 			if(!$name) $name = $ename;
@@ -2315,11 +2318,11 @@ if(defined('URL_PARAMETER') && URL_PARAMETER){
 	}else{
 		$urlparameter = "";
 }
-	$str = "<!DOCTYPE html>\n<html lang=\"ja\"><head><meta http-equiv=\"refresh\" content=\"1;URL=".PHP_SELF2.$urlparameter."\">\n";
+	$str = "<!DOCTYPE html>\n<html lang=\"ja\"><head><meta http-equiv=\"refresh\" content=\"1; URL=".PHP_SELF2.$urlparameter."\">\n";
 	
 	$str.= "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1.0,minimum-scale=1.0\">\n<meta charset=\"".CHARSET_HTML."\"></head>\n";
 	if(!isset($mes)){$mes="";}
-	$str.= "<body>$mes 画面を切り替えます</body></html>";
+	$str.= "<body>".$mes." 画面を切り替えます</body></html>";
 	echo charconvert($str,4);
 }
 
@@ -2373,7 +2376,7 @@ function replace($no,$pwd,$stime){
 			list($uip,$uhost,$uagent,$imgext,$ucode,$urepcode) = explode("\t", rtrim($userdata));
 			$file_name = preg_replace("/\.(dat)$/i","",$file);
 			//画像があり、認識コードがhitすれば抜ける
-			if(file_exists(TEMP_DIR.$file_name.$imgext) && $urepcode == $repcode){$find=true;break;}
+			if(file_exists(TEMP_DIR.$file_name.$imgext) && $urepcode === $repcode){$find=true;break;}
 		}
 	}
 	closedir($handle);
@@ -2427,13 +2430,13 @@ function replace($no,$pwd,$stime){
 	$buf = charconvert($buf,4);
 	$line = explode("\n",$buf);
 	$countline=count($line);
-	for($i = 0; $i < $countline; $i++){
+	for($i = 0; $i < $countline; ++$i){
 		if($line[$i]!=""){$line[$i].="\n";}}
 
 	// 記事上書き
 	$flag = false;
 	$countline = count($line);
-	for($i = 0; $i < $countline; $i++){
+	for($i = 0; $i < $countline; ++$i){
 		list($eno,,$name,$email,$sub,$com,$url,$ehost,$epwd,$ext,$W,$H,$etim,,$eptime,$fcolor) = explode(",", rtrim($line[$i]));
 		if($eno == $no && ($pwd == $epwd /*|| $ehost == $host*/ || $pwd == substr(md5(ADMIN_PASS),2,8))){
 			$upfile = $temppath.$file_name.$imgext;
@@ -2515,11 +2518,11 @@ if(defined('URL_PARAMETER') && URL_PARAMETER){
 	}else{
 		$urlparameter = "";
 }
-	$str = "<!DOCTYPE html>\n<html lang=\"ja\"><head><meta http-equiv=\"refresh\" content=\"1;URL=".PHP_SELF2.$urlparameter."\">\n";
+	$str = "<!DOCTYPE html>\n<html lang=\"ja\"><head><meta http-equiv=\"refresh\" content=\"1; URL=".PHP_SELF2.$urlparameter."\">\n";
 	
 	$str.= "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1.0,minimum-scale=1.0\">\n<meta charset=\"".CHARSET_HTML."\"></head>\n";
 	if(!isset($mes)){$mes="";}
-	$str.= "<body>$mes 画面を切り替えます</body></html>";
+	$str.= "<body>".$mes." 画面を切り替えます</body></html>";
 	echo charconvert($str,4);
 }
 
@@ -2529,7 +2532,7 @@ function catalog(){
 
 	$line = file(LOGFILE);
 	$countline=count($line);
-	for($i = 0; $i < $countline; $i++){
+	for($i = 0; $i < $countline; ++$i){
 		list($no,) = explode(",", $line[$i]);
 		$lineindex[$no]=$i + 1; //逆変換テーブル作成
 	}
@@ -2542,7 +2545,7 @@ function catalog(){
 	head($dat);
 	form($dat,'');
 	if(!$page) $page=0;
-	for($i = $page; $i < $page+$pagedef; $i++){
+	for($i = $page; $i < $page+$pagedef; ++$i){
 //		if($tree[$i]==""){
 //空文字ではなく未定義になっている
 		if(!isset($tree[$i])){
@@ -2707,7 +2710,7 @@ function potitag($str){
 				if(preg_match('/f\(([^\)]+)\)/',$base_tag,$m)){
 					$face = $m[1];
 					$countryfont1 = count($ryfont1);
-					for($i = 0; $i < $countryfont1; $i++){
+					for($i = 0; $i < $countryfont1; ++$i){
 						if($face == $ryfont1[$i]){$face = $ryfont2[$i];}
 					}
 				}
@@ -2719,7 +2722,7 @@ function potitag($str){
 				$rb_chk = 1;
 			}else{
 				$counttags1 = count($tags1);
-				for($i = 0; $i < $counttags1; $i++){
+				for($i = 0; $i < $counttags1; ++$i){
 					if($base_tag==$tags1[$i]){
 						array_push($tag_ex,'<'.$tags2[$i].'>');
 						$endtag = preg_replace("/^([[:alpha:]]+)(.*)/",'\\1',$tags2[$i]);
@@ -2745,7 +2748,7 @@ function potitag($str){
 			array_unshift($tag_ed,"</font>");
 		}
 		$counttag_ex=count($tag_ex);
-		for($i = 0; $i < $counttag_ex; $i++){
+		for($i = 0; $i < $counttag_ex; ++$i){
 			$com = $tag_ex[$i].$com.$tag_ed[$i];
 		}
 		array_push($tagrps2,$com);


### PR DESCRIPTION
https:// http:// ではじまるXSSのコードがオートリンクやurl欄のリンクにならないように蓋をしました。
もし本文にscriptがあったらオートリンクが有効にならないように。
<をChromeは "<" と解釈してscriptを実行するので、url欄を（&amp;lt;|</）でフィルタリング。
ペイントのテンプレートの484行目の開始タグと538行目の&#x3C;/form&#x3E;を削除。
formタグは入れ子にできない
https://qiita.com/k5trismegistus/items/eda92664037f96f40e37
フォームに入力候補が入ってしまうのでテンプレートのNo.の箇所のオートコンプリートをoffに。
処理速度をあげるため、++の前後位置、文字列内の変数展開の見直し（修正が容易なところだけ）を行いました。
NEOのバージョンを1.5.1にしました。