### PR TITLE
lot.190530

### DIFF
--- a/potiboard/config.php
+++ b/potiboard/config.php
@@ -150,11 +150,11 @@ $qualitys = array('1','2','3','4');
 //　セキュリティ関連－URLとクリック数かタイマーのどちらかが設定されていれば有効
 //※アプレットのreadmeを参照し、十分テストした上で設定して下さい
 //セキュリティクリック数。設定しないなら''で
-define('SECURITY_CLICK', '100');
+define('SECURITY_CLICK', '40');
 //セキュリティタイマー(単位:秒)。設定しないなら''で
-define('SECURITY_TIMER', '180');
+define('SECURITY_TIMER', '60');
 //セキュリティにヒットした場合の飛び先
-define('SECURITY_URL', 'http://www.npa.go.jp/');
+define('SECURITY_URL', './');
 
 //続きを描くときのセキュリティ。利用しないなら両方''で
 //続きを描くときのセキュリティクリック数。設定しないなら''で
@@ -181,7 +181,7 @@ define('TO_MAIL', 'root@xxx.xxx');
 
 //メール通知のほか、シェアボタンなどで使用
 //設置場所のURL。'/'まで
-define('ROOT_URL', 'http://www.xxx.com/poti/');
+define('ROOT_URL', 'http://www.hoge.ne.jp/');
 
 //メール通知に本文を付ける 付ける:1 付けない:0
 define('SEND_COM', '0');
@@ -354,7 +354,7 @@ define('KASIRA', 'OB');
 define('TEMP_DIR', 'tmp/');
 
 //テンポラリ内のファイル有効期限(日数)
-define('TEMP_LIMIT', '14');
+define('TEMP_LIMIT', '3');
 
 //お絵描き最大サイズ（これ以上は強制でこの値
 //最小値は幅、高さともに 100 固定です

--- a/potiboard/potiboard.php
+++ b/potiboard/potiboard.php
@@ -1,7 +1,7 @@
 <?php
 /*
   *
-  * POTI-board改 v1.51.6 lot.190528
+  * POTI-board改 v1.51.7 lot.190530
   *   (C)sakots >> https://sakots.red/poti/
   *
   *----------------------------------------------------------------------------------
@@ -204,8 +204,8 @@ if((THUMB_SELECT==0 && gd_check()) || THUMB_SELECT==1){
 define('USE_MB' , '1');
 
 //バージョン
-define('POTI_VER' , '改 v1.51.6');
-define('POTI_VERLOT' , '改 v1.51.6 lot.190528');
+define('POTI_VER' , '改 v1.51.7');
+define('POTI_VERLOT' , '改 v1.51.7 lot.190530');
 
 //メール通知クラスのファイル名
 define('NOTICEMAIL_FILE' , 'noticemail.inc');
@@ -1327,18 +1327,12 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 	setcookie ("pwdc", $c_pass,time()+SAVE_COOKIE*24*3600);
 	setcookie ("fcolorc", $fcolor,time()+SAVE_COOKIE*24*3600);
 
-	//クッキー項目："クッキー名<>クッキー値"　※漢字を含む項目はこちらに追加
-	$cooks = array("namec<>$names","emailc<>$email","urlc<>$url");
+	//クッキー項目："クッキー名<>クッキー値"　※漢字を含む項目はこちらに追加 //190528
+	$cooks = array("namec<>".$names,"emailc<>".$email,"urlc<>".$url);
 	foreach ( $cooks as $cook ) {
 		list($c_name,$c_cook) = explode('<>',$cook);
-		if(USE_MB){
 			mb_language(LANG);
 			$c_cookie = mb_convert_encoding($c_cook, "UTF-8", "auto");	//to UTF-8
-		}elseif(function_exists("iconv")){
-			$c_cookie = iconv("euc-jp", "UTF-8", $c_cook);	//to UTF-8
-		}else{
-			$c_cookie = $c_cook;
-		}
 		setcookie ($c_name, $c_cookie,time()+SAVE_COOKIE*24*3600);
 	}
 


### PR DESCRIPTION
//設置場所のURL。
にデフォルトで入っているドメインが実在していたため
http://www.hoge.ne.jp/ に変更しました。

セキュリティクリック数 セキュリティタイマー(単位:秒)
セキュリティにヒットした場合の飛び先
の見直し。
設置後のテスト投稿でしぃペインターを使った時に、ほぼ警視庁のサイトが表示されるため。

クッキーのテキストエンコード処理のコードを簡素化。

//テンポラリ内のファイル有効期限(日数)
define('TEMP_LIMIT', '3');
14日から3日に短縮。

いくつも画像が出てしまいますどうにかしてくださいと言われるケースが多かったため。
サーバが重い時にNEOで投稿ボタンを二度押しするとテンポラリに未投稿画像がたまります。従来の設定では未投稿画像が14日間表示されます。同じ画像なので同じ画像がありましたとなりユーザーでは対応できません。
短期間でプルリクした理由。
設置場所のurlの変更をしなければいけないと考えたからです。
よろしくお願いいたします。