### PR TITLE
190724

### DIFF
--- a/potiboard/htmltemplate.inc
+++ b/potiboard/htmltemplate.inc
@@ -59,11 +59,11 @@ define('FILE_READ_UNIT',8192);
 
 /* the origine class of all tags */
 class TagBasis{
-	var $matchregexp;
-	var $fromstring;
-	var $tostring;
-	var $closestring;
-	var $regardasarray=false;
+	public $matchregexp;
+	public $fromstring;
+	public $tostring;
+	public $closestring;
+	public $regardasarray=false;
 
 	function getLabelArray($str){
 		$ans=array();
@@ -207,53 +207,53 @@ class TemplateParser{
 */
 
 class tag_val extends DataTag{
-	var $matchregexp='/\{val ([^\}]+)\}/i';
-	var $fromstring="{val %s}";
-	var $tostring="<?php @print nl2br(\$val%1\$s); ?>\n";
+	public $matchregexp='/\{val ([^\}]+)\}/i';
+	public $fromstring="{val %s}";
+	public $tostring="<?php @print nl2br(\$val%1\$s); ?>\n";
 }
 
 class tag_rval extends DataTag{
-	var $matchregexp='/\{rval ([^\}]+)\}/i';
-	var $fromstring="{rval %s}";
-	var $tostring="<?php @print \$val%1\$s; ?>\n";
+	public $matchregexp='/\{rval ([^\}]+)\}/i';
+	public $fromstring="{rval %s}";
+	public $tostring="<?php @print \$val%1\$s; ?>\n";
 }
 
 // contributed by Osamu Shigematsu
 class tag_def extends ArrayTag{
-	var $matchregexp='/<!--\{def ([^\}]+)\}-->/i';
-	var $fromstring="<!--{def %s}-->";
-	var $tostring="<?php
+	public $matchregexp='/<!--\{def ([^\}]+)\}-->/i';
+	public $fromstring="<!--{def %s}-->";
+	public $tostring="<?php
 		if(@count(\$val%1\$s) && (is_array(\$val%1\$s) || strlen(\$val%1\$s))){ ?>";
-	var $closestring="<!--{/def}-->";
+	public $closestring="<!--{/def}-->";
 }
 
 //contributed by Ahiru,FB,masao,,,,
 class tag_ndef extends ArrayTag{
-	var $matchregexp='/<!--\{ndef ([^\}]+)\}-->/i';
-	var $fromstring="<!--{ndef %s}-->";
-	var $tostring="<?php
+	public $matchregexp='/<!--\{ndef ([^\}]+)\}-->/i';
+	public $fromstring="<!--{ndef %s}-->";
+	public $tostring="<?php
 		if(!(@count(\$val%1\$s) && (is_array(\$val%1\$s) || strlen(\$val%1\$s)))){ ?>";
-	var $closestring="<!--{/ndef}-->";
+	public $closestring="<!--{/ndef}-->";
 }
 
 // this vdef is an experimental tag.
 class tag_vdef extends DataTag{
-	var $matchregexp='/<!--\{vdef ([^\}]+)\}-->/i';
-	var $fromstring="<!--{vdef %s}-->";
-	var $tostring="<?php
+	public $matchregexp='/<!--\{vdef ([^\}]+)\}-->/i';
+	public $fromstring="<!--{vdef %s}-->";
+	public $tostring="<?php
 		if(@\$val%1\$s && ((gettype(\$val%1\$s)!=='array' && \$val%1\$s!==\"\") or (gettype(\$val%1\$s)==='array' && count(\$val%1\$s)>0))){ ?>";
-	var $closestring="<!--{/vdef}-->";
-	var $regardasarray=1;
+	public $closestring="<!--{/vdef}-->";
+	public $regardasarray=1;
 }
 
 class tag_each extends ArrayTag{
-	var $matchregexp='/<!--\{each ([^\}]+)\}-->/i';
-	var $fromstring="<!--{each %s}-->";
-	var $tostring="<?php
+	public $matchregexp='/<!--\{each ([^\}]+)\}-->/i';
+	public $fromstring="<!--{each %s}-->";
+	public $tostring="<?php
 			for(@\$cnt[\"%2\$s\"]=0;@\$cnt[\"%2\$s\"]<count(@\$val%1\$s);@\$cnt[\"%2\$s\"]++){
 				?>";
-	var $closestring="<!--{/each}-->";
-	var $regardasarray=true;
+	public $closestring="<!--{/each}-->";
+	public $regardasarray=true;
 }
 
 /*<!--{comment}--> *** <!--{/comment}-->
@@ -261,10 +261,10 @@ class tag_each extends ArrayTag{
 * remove all characters between these tags.
 */
 class tag_comment extends ArrayTag{
-var $matchregexp='/<!--\{comment\}-->/i';
-var $fromstring="<!--{comment}-->";
-var $tostring="<?php if(FALSE){?>";
-var $closestring="<!--{/comment}-->";
+public $matchregexp='/<!--\{comment\}-->/i';
+public $fromstring="<!--{comment}-->";
+public $tostring="<?php if(FALSE){?>";
+public $closestring="<!--{/comment}-->";
 }
 
 /*
@@ -302,10 +302,7 @@ class htmltemplate{
 
 	// the static method to get the singleton instance
 
-//ここから下のfunctionにpublic staticを追加しstatic宣言。
-//PHP7のE_DEPRECATEDの非推奨のエラーはでなくなったが
-//PHP4の文法でインスタンスを使用しているので
-//可能であれば修正したほうが良い。
+//functionにpublic staticを追加しstatic宣言。
 //PHP マニュアル
 //http://jp2.php.net/manual/ja/language.oop5.static.php
 //2018.09.22

--- a/potiboard/noticemail180605/utf-8/noticemail.inc
+++ b/potiboard/noticemail180605/utf-8/noticemail.inc
@@ -1,12 +1,13 @@
 <?php
 /*
-** メール通知クラス(UTF-8) lot.190721
+** メール通知クラス(UTF-8) lot.190724
 **
 ** http://www.punyu.net/php/
 ** by SakaQ
 ** https://sakots.red/poti/
 ** by sakots
 **
+** 2019/07/24 変換元のエンコードをutf-8に。コード整理。
 ** 2019/07/21 コード整理
 ** 2019/06/25 コード整理
 ** 2018/12/02 php7の静的コール警告エラー対応
@@ -80,28 +81,27 @@ noticemail::send($data);
 
 class noticemail{
 
-	public static function send($data,$usemb="1"){
+	public static function send($data){
 	$name = $data['name'];
 	$from = $data['email'];
 	$line = "---------------------------------------------------------------------\n";
 
 	// ヘッダを指定
-	$MailHeaders = "Mime-Version: 1.0\n";
-	$MailHeaders .= "Content-Type: text/plain; charset=ISO-2022-JP\n";
-	$MailHeaders .= "Content-Transfer-Encoding: 7bit\n";
-	$MailHeaders .= "X-Mailer: NoticeMail/PHP".phpversion()."\n";
+	$MailHeaders = 'Mime-Version: 1.0'."\n";
+	$MailHeaders .= 'Content-Type: text/plain; charset=ISO-2022-JP'."\n";
+	$MailHeaders .= 'Content-Transfer-Encoding: 7bit'."\n";
 
 	// メール本文作成
-	$Message = "■".$data['subject']."\n";
-	$Message .= "Date: ".date("Y/m/d H:i:s",time())."\n";
-	$Message .= "Host: ".gethostbyaddr(getenv("REMOTE_ADDR"))."\n";
-	$Message .= "UserAgent: ".getenv("HTTP_USER_AGENT")."\n";
+	$Message = '■'.$data['subject']."\n";
+	$Message .= 'Date: '.date("Y/m/d H:i:s",time())."\n";
+	$Message .= 'Host: '.gethostbyaddr(getenv("REMOTE_ADDR"))."\n";
+	$Message .= 'UserAgent: '.getenv("HTTP_USER_AGENT")."\n";
 	$Message .= $line;
-	$Message .= "Name: ".$name."\n";
-	$Message .= "e-Mail: ".$data['email']."\n";
+	$Message .= 'Name: '.$name."\n";
+	$Message .= 'e-Mail: '.$data['email']."\n";
 	$option = $data['option'];
 	if(is_array($option)){
-	foreach($option as $value){ list($optitle,$opvalue)=explode(",", rtrim($value)); $Message .=$optitle.": ".$opvalue." \n"; }
+	foreach($option as $value){ list($optitle,$opvalue)=explode(",", rtrim($value)); $Message .=$optitle.': '.$opvalue." \n"; }
 	}
 	unset($value);
 		$Message .= $line;
@@ -111,7 +111,6 @@ class noticemail{
 			$com = preg_replace("/^(\n)+|(\n)+$/i", "", $com);	// 連続改行を消す
 			$Message .= $com;
 		}
-		if($usemb){
 		mb_internal_encoding("UTF-8");
 		// 半角対応
 		$Message = mb_convert_kana($Message);
@@ -123,20 +122,18 @@ class noticemail{
 		if(!$from) $from = 'nomail@'.getenv("HTTP_HOST");
 		// 日本語ならMIMEヘッド
 		if(preg_match("/[\x80-\xA0]/",$name)){
-		$name = "=?iso-2022-jp?B?".base64_encode(mb_convert_encoding($name,"JIS","auto"))."?=";
+		$name = "=?iso-2022-jp?B?".base64_encode(mb_convert_encoding($name,"JIS","utf-8"))."?=";
 		}
 		// ヘッダにFrom追加
-		$MailHeaders .= "From: ".$name." <".$from.">\n";
+		$MailHeaders .= 'From: '.$name.' <'.$from.'>'."\n";
 			// Subjectに日本語があればMIMEヘッド
 			if(preg_match("/[\x80-\xA0]/",$data['subject'])){
-			$data['subject'] = "=?iso-2022-jp?B?".base64_encode(mb_convert_encoding($data['subject'],"JIS","auto"))."?=";
+			$data['subject'] = "=?iso-2022-jp?B?".base64_encode(mb_convert_encoding($data['subject'],"JIS","utf-8"))."?=";
 			} // メール送信
 			mail($data['to'],
 			$data['subject'],
-			mb_convert_encoding($Message,"JIS","auto"), $MailHeaders);
+			mb_convert_encoding($Message,"JIS","utf-8"), $MailHeaders);
 
-			}
-			else{ return false; }
 			return true;
 			}
 			}

--- a/potiboard/potiboard.php
+++ b/potiboard/potiboard.php
@@ -1,7 +1,7 @@
 <?php
 /*
   *
-  * POTI-board改 v1.52.5 lot.190721
+  * POTI-board改 v1.52.6 lot.190724
   *   (C)sakots >> https://sakots.red/poti/
   *
   *----------------------------------------------------------------------------------
@@ -176,8 +176,8 @@ if((THUMB_SELECT==0 && gd_check()) || THUMB_SELECT==1){
 define('USE_MB' , '1');
 
 //バージョン
-define('POTI_VER' , '改 v1.52.5');
-define('POTI_VERLOT' , '改 v1.52.5 lot.190721');
+define('POTI_VER' , '改 v1.52.6');
+define('POTI_VERLOT' , '改 v1.52.6 lot.190724');
 
 //メール通知クラスのファイル名
 define('NOTICEMAIL_FILE' , 'noticemail.inc');
@@ -193,111 +193,111 @@ date_default_timezone_set('Asia/Tokyo');
 //{$hoge}
 //rvalじゃ長いので$で定義
 class tag_rval2 extends DataTag{
-var $matchregexp='/\{\$([^\}]+)\}/i';
-var $fromstring="{\$%s}";
-var $tostring="<?php @print \$val%1\$s; ?>\n";
+public $matchregexp='/\{\$([^\}]+)\}/i';
+public $fromstring="{\$%s}";
+public $tostring="<?php @print \$val%1\$s; ?>\n";
 }
 //<!--{def hoge}-->～<!--{/def}-->
 //旧タイプに再定義
 class tag_def2 extends ArrayTag{
-var $matchregexp='/<!--\{def ([^\}]+)\}-->/i';
-var $fromstring="<!--{def %s}-->";
-var $tostring="<?php
+public $matchregexp='/<!--\{def ([^\}]+)\}-->/i';
+public $fromstring="<!--{def %s}-->";
+public $tostring="<?php
 if(@\$val%1\$s &&((gettype(\$val%1\$s)!=='array' && \$val%1\$s!==\"\") or (gettype(\$val%1\$s)==='array' && count(\$val%1\$s)>0))){ ?>";
-var $closestring="<!--{/def}-->";
+public $closestring="<!--{/def}-->";
 }
 //<!--{ndef hoge}-->～<!--{/ndef}-->
 //再定義(hogeが空(0も含む)の場合に、タグの間の～部分を表示する。defの逆)
 class tag_ndef2 extends ArrayTag{
-var $matchregexp='/<!--\{ndef ([^\}]+)\}-->/i';
-var $fromstring="<!--{ndef %s}-->";
-var $tostring="<?php
+public $matchregexp='/<!--\{ndef ([^\}]+)\}-->/i';
+public $fromstring="<!--{ndef %s}-->";
+public $tostring="<?php
 if(!(@\$val%1\$s &&((gettype(\$val%1\$s)!=='array' && \$val%1\$s!==\"\") or (gettype(\$val%1\$s)==='array' && count(\$val%1\$s)>0)))){ ?>";
-var $closestring="<!--{/ndef}-->";
+public $closestring="<!--{/ndef}-->";
 }
 //<!--{vdef hoge}-->～<!--{/vdef}-->
 //新タイプ(0もある物とみなす)で再定義
 class tag_vdef2 extends ArrayTag{
-var $matchregexp='/<!--\{vdef ([^\}]+)\}-->/i';
-var $fromstring="<!--{vdef %s}-->";
-var $tostring="<?php
+public $matchregexp='/<!--\{vdef ([^\}]+)\}-->/i';
+public $fromstring="<!--{vdef %s}-->";
+public $tostring="<?php
 if(@count(\$val%1\$s) && (is_array(\$val%1\$s) || strlen(\$val%1\$s))){ ?>";
-var $closestring="<!--{/vdef}-->";
+public $closestring="<!--{/vdef}-->";
 }
 //<!--{ifeq hoge:val}-->～<!--{/ifeq}-->
 // hoge = val の場合、タグの間の～部分を表示する
 class tag_ifeq extends DataTag{
-var $matchregexp='/<!--\{ifeq ([^\}:]+):([^\}:]+)\}-->/i';
-var $fromstring="<!--{ifeq %1\$s:%2\$s}-->";
-var $tostring="<?php
+public $matchregexp='/<!--\{ifeq ([^\}:]+):([^\}:]+)\}-->/i';
+public $fromstring="<!--{ifeq %1\$s:%2\$s}-->";
+public $tostring="<?php
 if(\$val%1\$s === '%3\$s'){ ?>";
-var $closestring="<!--{/ifeq}-->";
+public $closestring="<!--{/ifeq}-->";
 }
 //<!--{ifne hoge:val}-->～<!--{/ifne}-->
 // hoge != val の場合、タグの間の～部分を表示する
 class tag_ifne extends DataTag{
-var $matchregexp='/<!--\{ifne ([^\}:]+):([^\}:]+)\}-->/i';
-var $fromstring="<!--{ifne %1\$s:%2\$s}-->";
-var $tostring="<?php
+public $matchregexp='/<!--\{ifne ([^\}:]+):([^\}:]+)\}-->/i';
+public $fromstring="<!--{ifne %1\$s:%2\$s}-->";
+public $tostring="<?php
 if(\$val%1\$s !== '%3\$s'){ ?>";
-var $closestring="<!--{/ifne}-->";
+public $closestring="<!--{/ifne}-->";
 }
 //<!--{iflt hoge:val}-->～<!--{/iflt}-->
 // hoge < val の場合、タグの間の～部分を表示する
 class tag_iflt extends DataTag{
-var $matchregexp='/<!--\{iflt ([^\}:]+):([^\}:]+)\}-->/i';
-var $fromstring="<!--{iflt %1\$s:%2\$s}-->";
-var $tostring="<?php
+public $matchregexp='/<!--\{iflt ([^\}:]+):([^\}:]+)\}-->/i';
+public $fromstring="<!--{iflt %1\$s:%2\$s}-->";
+public $tostring="<?php
 if(\$val%1\$s < '%3\$s'){ ?>";
-var $closestring="<!--{/iflt}-->";
+public $closestring="<!--{/iflt}-->";
 }
 //<!--{ifgt hoge:val}-->～<!--{/ifgt}-->
 // hoge > val の場合、タグの間の～部分を表示する
 class tag_ifgt extends DataTag{
-var $matchregexp='/<!--\{ifgt ([^\}:]+):([^\}:]+)\}-->/i';
-var $fromstring="<!--{ifgt %1\$s:%2\$s}-->";
-var $tostring="<?php
+public $matchregexp='/<!--\{ifgt ([^\}:]+):([^\}:]+)\}-->/i';
+public $fromstring="<!--{ifgt %1\$s:%2\$s}-->";
+public $tostring="<?php
 if(\$val%1\$s > '%3\$s'){ ?>";
-var $closestring="<!--{/ifgt}-->";
+public $closestring="<!--{/ifgt}-->";
 }
 //<!--{ifle hoge:val}-->～<!--{/ifle}-->
 // hoge <= val の場合、タグの間の～部分を表示する
 class tag_ifle extends DataTag{
-var $matchregexp='/<!--\{ifle ([^\}:]+):([^\}:]+)\}-->/i';
-var $fromstring="<!--{ifle %1\$s:%2\$s}-->";
-var $tostring="<?php
+public $matchregexp='/<!--\{ifle ([^\}:]+):([^\}:]+)\}-->/i';
+public $fromstring="<!--{ifle %1\$s:%2\$s}-->";
+public $tostring="<?php
 if(\$val%1\$s <= '%3\$s'){ ?>";
-var $closestring="<!--{/ifle}-->";
+public $closestring="<!--{/ifle}-->";
 }
 //<!--{ifge hoge:val}-->～<!--{/ifge}-->
 // hoge >= val の場合、タグの間の～部分を表示する
 class tag_ifge extends DataTag{
-var $matchregexp='/<!--\{ifge ([^\}:]+):([^\}:]+)\}-->/i';
-var $fromstring="<!--{ifge %1\$s:%2\$s}-->";
-var $tostring="<?php
+public $matchregexp='/<!--\{ifge ([^\}:]+):([^\}:]+)\}-->/i';
+public $fromstring="<!--{ifge %1\$s:%2\$s}-->";
+public $tostring="<?php
 if(\$val%1\$s >= '%3\$s'){ ?>";
-var $closestring="<!--{/ifge}-->";
+public $closestring="<!--{/ifge}-->";
 }
 //{?}
 //通常はエスケープさせないでスルー
 class q_escape extends DataTag{
-var $matchregexp='/\{\?\}/i';
-var $fromstring="{?}";
-var $tostring="?";
+public $matchregexp='/\{\?\}/i';
+public $fromstring="{?}";
+public $tostring="?";
 }
 //メインの書込み時のみエスケープ
 class q_escape2 extends DataTag{
-var $matchregexp='/\{\?\}/i';
-var $fromstring="{?}";
-var $tostring="<?php @print '?'; ?>";
+public $matchregexp='/\{\?\}/i';
+public $fromstring="{?}";
+public $tostring="<?php @print '?'; ?>";
 }
 //<!--(～)-->
 //～部分を表示しない
 class tag_comment2 extends ArrayTag{
-var $matchregexp='/<!--\(/i';
-var $fromstring="<!--(";
-var $tostring="<?php if(FALSE){?>";
-var $closestring=")-->";
+public $matchregexp='/<!--\(/i';
+public $fromstring="<!--(";
+public $tostring="<?php if(FALSE){?>";
+public $closestring=")-->";
 }
 
 htmltemplate::removeTag("tag_rval");
@@ -1370,19 +1370,19 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 		if(file_exists(PCH_DIR.$tim.'.spch')) $data['option'][] = 'アニメファイル,'.ROOT_URL.PCH_DIR.$tim.'.spch';
 		if($resto){
 			$data['subject'] = '['.TITLE.'] No.'.$resto.'へのレスがありました';
-			$data['option'][] = "\n記事URL,".ROOT_URL.PHP_SELF.'?res='.$resto;
+			$data['option'][] = "\n".'記事URL,'.ROOT_URL.PHP_SELF.'?res='.$resto;
 		}else{
 			$data['subject'] = '['.TITLE.'] 新規投稿がありました';
-			$data['option'][] = "\n記事URL,".ROOT_URL.PHP_SELF.'?res='.$no;
+			$data['option'][] = "\n".'記事URL,'.ROOT_URL.PHP_SELF.'?res='.$no;
 		}
 		if(SEND_COM){
-		$data['comment'] = preg_replace("#<br(( *)|( *)/)>#i","\n", $com);	
+		$data['comment'] = preg_replace("#<br(( *)|( *)/)>#i","\n", $com);
 		}
 		else{
 		$data['comment'] ="";
 		}
 
-		noticemail::send($data,USE_MB);
+		noticemail::send($data);
 	}
 
 	header("Content-type: text/html; charset=UTF-8");
@@ -1687,6 +1687,101 @@ function paintform($picw,$pich,$palette,$anime,$pch=""){
 
 	global $useneo; //NEOを使う
 	if ($useneo) $dat['useneo'] = true; //NEOを使う
+
+//pchファイルアップロードペイント
+	if($admin===ADMIN_PASS){
+if(isset($_FILES['pch_upload']['name'])){
+	$pchup=$_FILES['pch_upload']['name'];
+	if($pchup!==""){//空文字でなければ続行
+	$pchtmp=$_FILES['pch_upload']['tmp_name'];
+$pchup=CleanStr($pchup);
+if (strpos($pchup, '/') !== false) {//ファイル名に/がなければ続行
+	echo "不正なファイルです。";
+$pchup="";
+$pchtmp="";
+	}
+	else{//チェック通過
+//拡張子チェック
+$tim = time().substr(microtime(),2,3);
+$ext=pathinfo($pchup, PATHINFO_EXTENSION);
+$ext=strtolower($ext);//すべて小文字に
+if($ext==="pch"){
+$type_pch=true;
+$pchup = TEMP_DIR.'tmp-'.$tim.'.pch';//アップロードされるファイル名
+}
+elseif($ext==="spch"){
+$type_spch=true;
+$type_pch=false;
+$pchup = TEMP_DIR.'tmp-'.$tim.'.spch';//アップロードされるファイル名
+}
+else{//拡張子が一致しなかったら
+$pchup="";
+$pchtmp="";
+echo "アニメファイルをアップしてください。";
+}
+unset($ext);
+if(move_uploaded_file($pchtmp, $pchup)){//アップロード成功なら続行
+$pchup=TEMP_DIR.basename($pchup);//ファイルを開くディレクトリを固定
+if(mime_content_type($pchup)==="application/octet-stream"){//mimetypeが正しければ続行
+//	var_dump(mime_content_type($pchup));
+$fp = fopen("$pchup", "rb");
+$line = bin2hex(fgets($fp ,4096)) ;
+//	var_dump()
+//var_dump($line);
+//var_dump(mime_content_type($pchup));
+if($type_pch){
+	$line = substr($line,0,6);
+	if($line==="4e454f"){
+	$useneo=true;
+	$dat['useneo'] = true;
+	}
+	else{//NEOのpchでなければ
+	echo"NEOのPCHではありません。";
+//		var_dump($line);
+		unlink($pchup);
+	}
+}
+elseif($type_spch){
+	$line = substr($line,0,24);
+//	$line2 = substr($line,0,30);
+	if($line==="6c617965725f636f756e743d"||$line==="000d0a"){
+	$useneo=false;
+	$dat['useneo'] = false;
+		}else{//しぃぺのspchでなければ
+	echo"しぃペインターのSPCHではありません。";
+		unlink($pchup);
+	}
+//		var_dump($line);
+	
+}
+else{
+	unlink($pchup);
+	echo"アニメファイルをアップしてください。";
+}
+	fclose($fp);
+	$dat['pchfile'] = $pchup;
+}
+else{//mime_content_typeが違ったら
+	unlink($pchup);
+	echo"アニメファイルをアップしてください。";
+//	error(MSG001);
+}
+
+//var_dump(pathinfo($pchup, PATHINFO_EXTENSION));
+//var_dump($line);
+	}
+	}//不正なファイルでは無い時は
+	}//空文字列でなければ処理続行。
+else{
+$pchup="";
+$pchtmp="";
+}
+	}
+	else{//未定義なら
+		$_FILES['pch_upload']['tmp_name']="";
+	}
+}
+//pchファイルアップロードペイントここまで
 
 	if($picw < 100) $picw = 100;
 	if($pich < 100) $pich = 100;


### PR DESCRIPTION
>var を使ってプロパティを宣言した場合、PHP 5 はそれを public と同等とみなします。https://www.php.net/manual/ja/language.oop5.properties.php

該当箇所をpublic に書き直しました。

メール通知クラスの負荷削減。
変換元のエンコードをutf-8に。コード整理。
phpinfo()でphpのバージョンを送信していた箇所を削除。
（X-Mailer: NoticeMail/PHP7.3.6 は必須ではない）

しぃペインターのspchとneoのpchに対応したアップロードペイント機能をコードに追加。どう活用するかは今後の課題です。
現時点では管理画面で管理者が他のサイトで描いたアニメファイルをもちかえってアップロードペイントしてアニメファイル付きのイラストを投稿できる機能になっています。
対応テンプレートが必要。
実装例。
https://github.com/satopian/poti/blob/master/template/pink_other.html
の
&#x3C;input name=&#x22;submit&#x22; type=&#x22;submit&#x22; value=&#x22;PAINT&#x22; class=&#x22;paint_button&#x22;&#x3E;
以下。
今後この機能を通常の機能にするかどうかは要相談です。まだ隠し機能的オプションの段階。
ただ、今のままでも管理画面にアップロードペイント画面を作成すればとりあえず使う事はできます。
アップロードに成功しなかった時のエラーはechoが出るだけです。
アップロードしたファイルはテンポラリの掃除が入る期間が来るまでテンポラリに残ったままです。