### PR TITLE
スマートフォンで描く時の挙動の分岐

### DIFF
--- a/potiboard/nee_paint.html
+++ b/potiboard/nee_paint.html
@@ -2,7 +2,17 @@
 <html lang="ja">
 	<head>
 		<meta charset="{$charset}">
+	<!--{def paint_mode}-->
+	<!--{def pinchin}-->
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+	<!--{/def}-->
+	<!--{ndef pinchin}-->
+		<meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0">
+	<!--{/ndef}-->
+	<!--{/def}-->
+	<!--{ndef paint_mode}-->
+		<meta name="viewport" content="width=device-width,initial-scale=1">
+	<!--{/ndef}-->
 		<link rel="stylesheet" href="neo.css" type="text/css">
 		<script src="neo.js" charset="UTF-8"></script>
 		<link rel="stylesheet" href="nee_main.css" type="text/css">


### PR DESCRIPTION
![localhost_190910_potiboard php(iPhone 6_7_8) (2)](https://user-images.githubusercontent.com/44894014/64606188-a54ebc80-d400-11e9-89ae-ff82a84a6273.png)
![localhost_190910_potiboard php(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/44894014/64606198-aaac0700-d400-11e9-9069-33e7443cc38d.png)
上、ピンチインなし。下ピンチインあり。

スマートフォンで描く時のキャンバスサイズとユーザーエージェントによるviewportの分岐。

スマホで大きな絵を描きたいので、等倍以下の縮小表示（ピンチイン）ができたほうがいいという人と
小さな絵しか描かないので、窓モードが使いやすいピンチインなしの等倍表示までにしてほしいという人どちらも問題がでないようにするための調整です。

キャンバスサイズが500以上ならピンチインが有効になり、500未満ならピンチインが無効になる処理の追加。

また、画像重複をチェックする行数はこれまで200行でしたが、200行または画像20枚で処理を終了するようにしました。
（画像重複チェックの処理でis_file()を最大で200回実行したくない）
foreachでは配列の数だけループするので
配列をカウントして存在する行数のみチェックとしていた箇所を整理しました。