### PR TITLE
thumbnail_gd.php の細かな修正

### DIFF
--- a/potiboard/thumbnail_gd.php
+++ b/potiboard/thumbnail_gd.php
@@ -23,8 +23,8 @@ function thumb($path,$tim,$ext,$max_w,$max_h){
 		case 1 :
 			if(function_exists("ImageCreateFromGIF")){//gif
 				$im_in = @ImageCreateFromGIF($fname);
+				if(!$im_in)return;
 			}
-			if(!$im_in)return;
 			break;
 		case 2 :
 			$im_in = @ImageCreateFromJPEG($fname);//jpg
@@ -33,8 +33,8 @@ function thumb($path,$tim,$ext,$max_w,$max_h){
 		case 3 :
 			if(function_exists("ImageCreateFromPNG")){//png
 				$im_in = @ImageCreateFromPNG($fname);
+				if(!$im_in)return;
 			}
-			if(!$im_in)return;
 			break;
 		default : return;
 	}


### PR DESCRIPTION
ImageCreateFromGIF()などの関数の処理が成功したかどうか確認するための
変数 $im_in が
関数が未定義の時に、未定義変数になるため書き直しました。
関数の処理に失敗した時の動作に問題がない（処理できないだけで終わる）事を確認しました。
gif、jpg、pngそれぞれの画像が、jpgのサムネイルになる事を再度確認しました。