### PR TITLE
thumbnail_gd.phpの細かな修正

### DIFF
--- a/potiboard/thumbnail_gd.php
+++ b/potiboard/thumbnail_gd.php
@@ -25,17 +25,23 @@ function thumb($path,$tim,$ext,$max_w,$max_h){
 				$im_in = @ImageCreateFromGIF($fname);
 				if(!$im_in)return;
 			}
-			break;
+			else{
+				return;
+			}
+		break;
 		case 2 :
 			$im_in = @ImageCreateFromJPEG($fname);//jpg
 			if(!$im_in)return;
-			break;
+		break;
 		case 3 :
 			if(function_exists("ImageCreateFromPNG")){//png
 				$im_in = @ImageCreateFromPNG($fname);
 				if(!$im_in)return;
 			}
-			break;
+			else{
+				return;
+			}
+		break;
 		default : return;
 	}
 	// 出力画像（サムネイル）のイメージを作成


### PR DESCRIPTION
お手数をおかけします。
関数が未定義の時にユーザー定義関数からreturnする処理をしていませんでした。
修正後、存在しない関数をいれて動作確認し処理されないだけでエラーにならない事を確認しました。（returnでユーザー定義関数から抜ける）