### PR TITLE
getenv("REMOTE_ADDR")でipを取得できないサーバに対応

### DIFF
--- a/potiboard/noticemail180605/utf-8/noticemail.inc
+++ b/potiboard/noticemail180605/utf-8/noticemail.inc
@@ -7,6 +7,7 @@
 ** https://sakots.red/poti/
 ** by sakots
 **
+** 2020/01/25 "REMOTE_ADDR"が使えないサーバに対応。
 ** 2019/07/24 変換元のエンコードをutf-8に。コード整理。
 ** 2019/07/21 コード整理
 ** 2019/06/25 コード整理
@@ -94,7 +95,15 @@ class noticemail{
 	// メール本文作成
 	$Message = '■'.$data['subject']."\n";
 	$Message .= 'Date: '.date("Y/m/d H:i:s",time())."\n";
-	$Message .= 'Host: '.gethostbyaddr(getenv("REMOTE_ADDR"))."\n";
+	//ユーザーip
+	$userip = getenv("HTTP_CLIENT_IP");
+	if(!$userip){
+		$userip = getenv("HTTP_X_FORWARDED_FOR");
+	} 
+	if(!$userip){
+		$userip = getenv("REMOTE_ADDR");
+	} 
+	$Message .= 'Host: '.gethostbyaddr($userip)."\n";
 	$Message .= 'UserAgent: '.getenv("HTTP_USER_AGENT")."\n";
 	$Message .= $line;
 	$Message .= 'Name: '.$name."\n";

--- a/potiboard/thumbnail_gd.php
+++ b/potiboard/thumbnail_gd.php
@@ -57,7 +57,7 @@ function thumb($path,$tim,$ext,$max_w,$max_h){
 	if($nottrue) ImageCopyResized($im_out, $im_in, 0, 0, 0, 0, $out_w, $out_h, $size[0], $size[1]);
 	// サムネイル画像を保存
 	ImageJPEG($im_out, THUMB_DIR.$tim.'s.jpg',THUMB_Q);
-	chmod(THUMB_DIR.$tim.'s.jpg',0666);
+	chmod(THUMB_DIR.$tim.'s.jpg',0606);
 	// 作成したイメージを破棄
 	ImageDestroy($im_in);
 	ImageDestroy($im_out);


### PR DESCRIPTION
### potiboard.php

> http://www.users-net.com/x/bbs3/c-board.cgi?cmd=one;no=84;id=XREA
> 代替サーバーを介するため、REMOTE_ADDR,REMOTE_HOSTが取得出来ません。
> REMOTE_ADDRの代わりに、HTTP_X_FORWARDED_FORを使って下さい。
> 

> https://qiita.com/reput0n/items/5b749de93df41f80f8c1
> XREAの共有SSLはプロキシサーバを経由することで実現しているらしく，「SSLドメイン」と「標準ドメイン」で違うアドレスが返ってくる
> 

↑
XREAのSSL環境ではREMOTE_ADDRにユーザーのipアドレスが入らないので、

HTTP_X_FORWARDED_FORで取得できなかった時はREMOTE_ADDRになるように変更しました。
以前はその処理が何箇所かありましたが整理していました。
もとからREMOTE_ADDRしか取得していなかった箇所が多数あったのでipアドレスを取得するユーザー定義関数 
**get_uip();**
を作りました。

取得方法を変更する事になってもその関数を書き直すだけですみます。
何度も REMOTE_ADDR を呼んでいた箇所を変数化。

### picpost.php
ファイルロックがphp3形式のままだったのを修正。

### thumbnail_gd.php
パーミッション666ではエラーになるサーバに対応。

### noticemail.inc 
REMOTE_ADDR でipアドレスを取得できないサーバに対応。