### PR TITLE
fwrite()100回→1回。未定義エラー修正。

### DIFF
--- a/potiboard/picpost.php
+++ b/potiboard/picpost.php
@@ -1,6 +1,6 @@
 <?php
 //----------------------------------------------------------------------
-// picpost.php lot.191203  by SakaQ >> http://www.punyu.net/php/
+// picpost.php lot.200211  by SakaQ >> http://www.punyu.net/php/
 // & sakots >> https://sakots.red/poti/
 //
 // しぃからPOSTされたお絵かき画像をTEMPに保存
@@ -8,6 +8,7 @@
 // このスクリプトはPaintBBS（藍珠CGI）のPNG保存ルーチンを参考に
 // PHP用に作成したものです。
 //----------------------------------------------------------------------
+// 2020/02/11 コード整理
 // 2020/01/25 REMOTE_ADDRが取得できないサーバに対応 ファイルロック修正
 // 2019/12/03 軽微なエラー修正。datファイルのパーミッションを600に
 // 2019/08/23 コード整理
@@ -40,16 +41,19 @@ function error($error){
 	$youbi = array('日','月','火','水','木','金','土');
 	$yd = $youbi[gmdate("w", $time+9*60*60)] ;
 	$now = gmdate("y/m/d",$time+9*60*60)."(".(string)$yd.")".gmdate("H:i",$time+9*60*60);
-	if(is_file($syslog)) $lines = file($syslog);
+	if(is_file($syslog)) {
+		$lines = file($syslog);
+		array_splice($lines, $syslogmax-1);//記録上限
+		$line=implode('',$lines);//これまでのエラー情報
+	}
+	else{
+		$line='';
+	}
 	$ep = @fopen($syslog , "w") or die($syslog."が開けません");
 	flock($ep, LOCK_EX);
-	fwrite($ep, $imgfile."  ".$error." [".$now."]\n");//最新のエラー情報
-	foreach($lines as $i=>$val){//これまでのエラー情報
-		if($i<$syslogmax){//記録行数上限
-		fwrite($ep, $val);
-		}	
-	}
-	unset($val);
+	$newline=$imgfile."  ".$error." [".$now."]\n";//最新のエラー情報
+	$newline.=$line;//最新とこれまでをまとめる
+	fwrite($ep,$newline);
 	fflush($ep);
 	flock($ep, LOCK_UN);
 	fclose($ep);

--- a/potiboard/potiboard.php
+++ b/potiboard/potiboard.php
@@ -2,7 +2,7 @@
 // ini_set('error_reporting', E_ALL);
 /*
   *
-  * POTI-board改 v1.54.6 lot.200125
+  * POTI-board改 v1.54.7 lot.200211
   *   (C)sakots >> https://sakots.red/poti/
   *
   *----------------------------------------------------------------------------------
@@ -185,8 +185,8 @@ define('crypt_iv','T3pkYxNyjN7Wz3pu');//半角英数16文字
 define('USE_MB' , '1');
 
 //バージョン
-define('POTI_VER' , '改 v1.54.6');
-define('POTI_VERLOT' , '改 v1.54.6 lot.200125');
+define('POTI_VER' , '改 v1.54.7');
+define('POTI_VERLOT' , '改 v1.54.7 lot.200211');
 
 //メール通知クラスのファイル名
 define('NOTICEMAIL_FILE' , 'noticemail.inc');
@@ -518,7 +518,7 @@ unset($value);
 			$st = $page;
 		}
 		for($i = $st; $i < $st+PAGE_DEF; ++$i){
-//			if($tree[$i]=="") continue;
+			//if($tree[$i]=="") continue;
 			if(!isset($tree[$i])){
 			continue;
 			}
@@ -594,6 +594,7 @@ unset($value);
 				$resub = '';
 			}
 			// レス省略
+			$skipres = '';
 			if(!$resno){
 				$counttreeline = count($treeline);//190619
 				$s=$counttreeline - DSP_RES;
@@ -604,7 +605,7 @@ unset($value);
 				if(RES_UPLOAD){
 					//画像テーブル作成
 					$imgline=array();
-//					$counttreeline = count($treeline);//190619
+					//$counttreeline = count($treeline);//190619
 					for($k = $s; $k < $counttreeline; $k++){
 						$disptree = $treeline[$k];
 						$j=$lineindex[$disptree] - 1;
@@ -624,8 +625,8 @@ unset($value);
 						$s++;
 						$resimgs = array_count_values($imgline);
 					}
-				}
-					if($s>1) $skipres = $s - 1; //再計算
+					}
+					if($s>1) {$skipres = $s - 1;}//再計算
 				}
 			}else{
 				$s=1;
@@ -658,12 +659,9 @@ unset($value);
 			$com = preg_replace("{<br( *)/>}i","<br>",$com);
 			//独自タグ変換
 			if(USE_POTITAG) $com = potitag($com);
-	//メタタグに使うコメントから
-	//タグを除去
-	$descriptioncom=strip_tags($com);
-	if(!isset($skipres)){
-		$skipres="";
-	}
+			//メタタグに使うコメントから
+			//タグを除去
+			$descriptioncom=strip_tags($com);
 
 			// 親記事格納
 			$dat['oya'][$oya] = compact('src','srcname','size','painttime','pch','continue','thumb','imgsrc','w','h','no','sub','name','now','com','descriptioncom','limit','skipres','resub','url','email','id','updatemark','trip','tab','fontcolor');
@@ -671,6 +669,7 @@ unset($value);
 			unset($src,$srcname,$size,$painttime,$pch,$continue,$thumb,$imgsrc,$w,$h,$no,$sub,$name,$now,$com,$descriptioncom,$limit,$skipres,$resub,$url,$email);
 
 			//レス作成
+			$rres=array();
 			$counttreeline = count($treeline);
 			for($k = $s; $k < $counttreeline; $k++){
 				$disptree = $treeline[$k];
@@ -766,7 +765,7 @@ unset($value);
 						,$src,$srcname,$size,$painttime,$pch,$continue,$thumb,$imgsrc,$w,$h);
 			}
 			// レス記事一括格納
-			if($counttreeline>1){//レスがある時
+			if($rres){//レスがある時
 			$dat['oya'][$oya]['res'] = $rres[$oya];
 			}
 			unset($rres); //クリア
@@ -1999,7 +1998,7 @@ $mobile = (bool) strpos($_SERVER['HTTP_USER_AGENT'],'Mobile');
 		$dat['anime'] = false;
 		$dat['imgfile'] = './'.PCH_DIR.$pch.$ext;
 	}
-	if(ADMIN_NEWPOST&&$admin===ADMIN_PASS) $dat['admin'] = 'picpost';
+	// if(ADMIN_NEWPOST&&$admin===ADMIN_PASS) $dat['admin'] = 'picpost';
 
 	if(isset($C_Palette)){
 		for ($n = 1;$n < 7;++$n)
@@ -2113,7 +2112,7 @@ function paintcom($resto=''){
 			$dat['tmp'][] = compact('src','srcname','date');
 		}
 	}
-	if(ADMIN_NEWPOST&&$admin=='picpost') $dat['admin'] = $admin;
+	// if(ADMIN_NEWPOST&&$admin=='picpost') $dat['admin'] = $admin;
 	form($dat,$resto,'',$tmp);
 	htmloutput(OTHERFILE,$dat);
 }
@@ -3094,7 +3093,7 @@ paintform($picw,$pich,$palette,$anime);
 	case 'contpaint':
 //パスワードが必要なのは差し換えの時だけ
 		if(CONTINUE_PASS||$type==='rep') usrchk($no,$pwd);
-		if(ADMIN_NEWPOST) $admin=$pwd;
+		// if(ADMIN_NEWPOST) $admin=$pwd;
 		$palette="";
 		paintform($picw,$pich,$palette,$anime,$pch);
 		break;


### PR DESCRIPTION
### picpost.php

エラーの記録行数が100行の時100回fwrite()が実行されていたのを修正。
何件エラーが記録されていてもfwrite()1回で処理が終わるようになりました。

### potiboard.php

> //[新規投稿は管理者のみ]にする する:1 しない:0
> //する(1)にした場合、管理者パス以外での新規投稿はできません
> define('ADMIN_NEWPOST', '1');
> 

の時に未定義エラーが発生するのを修正。
isset()を削減。

「日記モドキ」テンプレートで、mode=piccom&admin=picpost の時に「管理モード」と表示するためのコードを削除。
&admin=picpostとブラウザで入力するとログインしていなくても「管理モード」と表示される問題も見つかりましたが該当行の削除で対応できました。