### PR TITLE
PaintBBS NEO v1.5.5のツールのツール表示位置左右切り替えに対応

### DIFF
--- a/potiboard/config.php
+++ b/potiboard/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
-  * POTI-board改 v1.55.2 lot.200401
+  * POTI-board改 v1.55.4 lot.200413
   * by sakots >> https://sakots.red/poti/
   *
   * POTI-board改の設定ファイルです。
@@ -386,7 +386,7 @@ define('TEMP_DIR', 'tmp/');
 define('TEMP_LIMIT', '3');
 
 //お絵描き最大サイズ（これ以上は強制でこの値
-//最小値は幅、高さともに 100 固定です
+//最小値は幅、高さともに 300 固定です
 define('PMAX_W', '600');	//幅
 define('PMAX_H', '600');	//高さ
 

--- a/potiboard/nee_paint.html
+++ b/potiboard/nee_paint.html
@@ -474,6 +474,11 @@
 				<div class="palette">
 					<form name="Palette">
 						<fieldset>
+							<legend>TOOL</legend>
+							<input class="button" type="button" value="左" onclick="Neo.setToolSide(true)">
+								<input class="button" type="button" value="右" onclick="Neo.setToolSide(false)">
+						</fieldset>	
+						<fieldset>
 							<legend>PALETTE</legend>
 							<select class="form" name="select" size="{$palsize}" onChange="setPalette()">
 								<option>一時パレット</option>

--- a/potiboard/neo.js
+++ b/potiboard/neo.js
@@ -11,11 +11,12 @@ document.addEventListener("DOMContentLoaded", function() {
 
 var Neo = function() {};
 
-Neo.version = "1.5.4";
+Neo.version = "1.5.5";
 Neo.painter;
 Neo.fullScreen = false;
 Neo.uploaded = false;
 Neo.viewer = false;
+Neo.toolSide = false;
 
 Neo.config = {
     width: 300,
@@ -1016,6 +1017,23 @@ Neo.tintImage = function(ctx, c) {
 };
 
 
+Neo.setToolSide = function(side) {
+    if (side === 'left') side = true;
+    if (side === 'right') side = false;
+    Neo.toolSide = !!side;
+
+    if (!Neo.toolSide) {
+        Neo.addRule(".NEO #toolsWrapper", "right", "0");
+        Neo.addRule(".NEO #toolsWrapper", "left", "auto");
+        Neo.addRule(".NEO #painterWrapper", "padding", "0 55px 0 0 !important");
+        Neo.addRule(".NEO #upper", "padding-right", "75px !important");
+    } else {
+        Neo.addRule(".NEO #toolsWrapper", "right", "auto");
+        Neo.addRule(".NEO #toolsWrapper", "left", "0");
+        Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
+        Neo.addRule(".NEO #upper", "padding-right", "20px !important");
+    }
+};
 
 'use strict';
 
@@ -5665,6 +5683,9 @@ Neo.ActionManager.prototype.line = function(
         x1 = item[14];
         y1 = item[15];
     }
+    if (x1 === null) x1 = x0
+    if (y1 === null) y1 = y0
+  
     oe.drawLine(oe.canvasCtx[layer], x0, y0, x1, y1, lineType);
     oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight);
 

--- a/potiboard/potiboard.php
+++ b/potiboard/potiboard.php
@@ -3,7 +3,7 @@
 //$time_start = microtime(true);
 /*
   *
-  * POTI-board改 v1.55.3 lot.200408
+  * POTI-board改 v1.55.4 lot.200413
   *   (C)sakots >> https://sakots.red/poti/
   *
   *----------------------------------------------------------------------------------
@@ -186,8 +186,8 @@ define('crypt_iv','T3pkYxNyjN7Wz3pu');//半角英数16文字
 define('USE_MB' , '1');
 
 //バージョン
-define('POTI_VER' , '改 v1.55.3');
-define('POTI_VERLOT' , '改 v1.55.3 lot.200408');
+define('POTI_VER' , '改 v1.55.4');
+define('POTI_VERLOT' , '改 v1.55.4 lot.200413');
 
 //メール通知クラスのファイル名
 define('NOTICEMAIL_FILE' , 'noticemail.inc');
@@ -1021,10 +1021,11 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 
 	if($REQUEST_METHOD !== "POST") error(MSG006);
 
-	//チェックする項目から改行や空白を消す
-	$chk_com  = preg_replace("/(\r\n|\r|\n| |　)/", "", $com );
-	$chk_name = preg_replace("/( |　)/", "", $name );
-	$chk_sub = preg_replace("/( |　)/", "", $sub );
+	//チェックする項目から改行・スペース・タブを消す
+	$chk_com  = preg_replace("/\s/u", "", $com );
+	$chk_name = preg_replace("/\s/u", "", $name );
+	$chk_sub = preg_replace("/\s/u", "", $sub );
+	$chk_email = preg_replace("/\s/u", "", $email );
 
 	//本文に日本語がなければ拒絶
 	if (USE_JAPANESEFILTER) {
@@ -1039,7 +1040,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 		if($value===''){
 		break;
 		}
-		if(preg_match("/$value/u",$chk_com)||preg_match("/$value/u",$chk_sub)||preg_match("/$value/u",$chk_name)||preg_match("/$value/u",$email)){
+		if(preg_match("/$value/ui",$chk_com)||preg_match("/$value/ui",$chk_sub)||preg_match("/$value/ui",$chk_name)||preg_match("/$value/ui",$chk_email)){
 			error(MSG032,$dest);
 		}
 	}
@@ -1049,7 +1050,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 			if($value===''){
 			break;
 			}
-			if(preg_match("/$value/u",$chk_name)){
+			if(preg_match("/$value/ui",$chk_name)){
 				error(MSG037,$dest);
 			}
 		}
@@ -1063,7 +1064,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 		if($value===''){
 		break;
 		}
-		if(preg_match("/$value/u",$chk_com)||preg_match("/$value/u",$chk_sub)||preg_match("/$value/u",$chk_name)||preg_match("/$value/u",$email)){
+		if(preg_match("/$value/ui",$chk_com)||preg_match("/$value/ui",$chk_sub)||preg_match("/$value/ui",$chk_name)||preg_match("/$value/ui",$chk_email)){
 			$bstr_A_find=true;
 		break;
 		}
@@ -1073,7 +1074,7 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 		if($value===''){
 		break;
 		}
-		if(preg_match("/$value/u",$chk_com)||preg_match("/$value/u",$chk_sub)||preg_match("/$value/u",$chk_name)||preg_match("/$value/u",$email)){
+		if(preg_match("/$value/ui",$chk_com)||preg_match("/$value/ui",$chk_sub)||preg_match("/$value/ui",$chk_name)||preg_match("/$value/ui",$chk_email)){
 			$bstr_B_find=true;
 		break;
 		}
@@ -1084,11 +1085,11 @@ function regist($name,$email,$sub,$com,$url,$pwd,$upfile,$upfile_name,$resto,$pi
 	}
 
 	// フォーム内容をチェック
-	if(!$name||preg_match("/^[ |　|]*$/",$name)) $name="";
-	if(!$com||preg_match("/^[ |　|\t]*$/",$com)) $com="";
-	if(!$sub||preg_match("/^[ |　|]*$/",$sub))   $sub="";
-	if(preg_match("/&lt;|</",$email))   $email="";//190602
-	if(!$url||!preg_match("/^ *?https?:\/\//",$url)||preg_match("/&lt;|</",$url))   $url="";
+	if(!$name||preg_match("/\A\s*\z/u",$name)) $name="";
+	if(!$com||preg_match("/\A\s*\z/u",$com)) $com="";
+	if(!$sub||preg_match("/\A\s*\z/u",$sub))   $sub="";
+	if(!$email||preg_match("/\A\s*\z|&lt;|</ui",$email)) $email="";
+	if(!$url||!preg_match("/\A *https?:\/\//",$url)||preg_match("/&lt;|</i",$url)) $url="";
 	if(!$resto&&!$textonly&&!$is_file_dest) error(MSG007,$dest);
 	if(RES_UPLOAD&&$resto&&!$textonly&&!$is_file_dest) error(MSG007,$dest);
 
@@ -1869,8 +1870,8 @@ if($admin===ADMIN_PASS){
 }
 //pchファイルアップロードペイントここまで
 
-	if($picw < 100) $picw = 100;
-	if($pich < 100) $pich = 100;
+	if($picw < 300) $picw = 300;
+	if($pich < 300) $pich = 300;
 	if($picw > PMAX_W) $picw = PMAX_W;
 	if($pich > PMAX_H) $pich = PMAX_H;
 //	$w = $picw + 150;
@@ -1879,8 +1880,20 @@ if($admin===ADMIN_PASS){
 	$h = $pich + 120;//しぃぺの時の高さ
 	}
 	else{
-	$w = $picw + 150;//PaintBBSの時の幅
-	$h = $pich + 170;//PaintBBSの時の高さ
+		if($pich<=300){
+			$w = $picw + 150;//PaintBBSの時の幅
+			$h = $pich + 255;//PaintBBSの時の高さ
+			}
+		elseif($pich<=350){
+				$w = $picw + 150;//PaintBBSの時の幅
+				$h = $pich + 220;//PaintBBSの時の高さ
+	
+		}
+		else{
+			$w = $picw + 150;//PaintBBSの時の幅
+			$h = $pich + 172;//PaintBBSの時の高さ
+
+		}
 	}
 	if($w < 400){$w = 400;}
 	if($h < 420){$h = 420;}
@@ -2378,10 +2391,11 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 
 	if($REQUEST_METHOD !== "POST") error(MSG006);
 
-	//チェックする項目から改行や空白を消す
-	$chk_com  = preg_replace("/(\r\n|\r|\n| |　)/", "", $com );
-	$chk_name = preg_replace("/( |　)/", "", $name );
-	$chk_sub = preg_replace("/( |　)/", "", $sub );
+	//チェックする項目から改行・スペース・タブを消す
+	$chk_com  = preg_replace("/\s/u", "", $com );
+	$chk_name = preg_replace("/\s/u", "", $name );
+	$chk_sub = preg_replace("/\s/u", "", $sub );
+	$chk_email = preg_replace("/\s/u", "", $email );
 
 	//本文に日本語がなければ拒絶
 	if (USE_JAPANESEFILTER) {
@@ -2396,7 +2410,7 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 		if($value===''){
 		break;
 		}
-		if(preg_match("/$value/u",$chk_com)||preg_match("/$value/u",$chk_sub)||preg_match("/$value/u",$chk_name)||preg_match("/$value/u",$email)){
+		if(preg_match("/$value/ui",$chk_com)||preg_match("/$value/ui",$chk_sub)||preg_match("/$value/ui",$chk_name)||preg_match("/$value/ui",$chk_email)){
 			error(MSG032,$dest);
 		}
 	}
@@ -2406,7 +2420,7 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 			if($value===''){
 			break;
 			}
-			if(preg_match("/$value/u",$chk_name)){
+			if(preg_match("/$value/ui",$chk_name)){
 				error(MSG037,$dest);
 			}
 		}
@@ -2420,7 +2434,7 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 		if($value===''){
 		break;
 		}
-		if(preg_match("/$value/u",$chk_com)||preg_match("/$value/u",$chk_sub)||preg_match("/$value/u",$chk_name)||preg_match("/$value/u",$email)){
+		if(preg_match("/$value/ui",$chk_com)||preg_match("/$value/ui",$chk_sub)||preg_match("/$value/ui",$chk_name)||preg_match("/$value/ui",$chk_email)){
 			$bstr_A_find=true;
 		break;
 		}
@@ -2430,7 +2444,7 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 		if($value===''){
 		break;
 		}
-		if(preg_match("/$value/u",$chk_com)||preg_match("/$value/u",$chk_sub)||preg_match("/$value/u",$chk_name)||preg_match("/$value/u",$email)){
+		if(preg_match("/$value/ui",$chk_com)||preg_match("/$value/ui",$chk_sub)||preg_match("/$value/ui",$chk_name)||preg_match("/$value/ui",$chk_email)){
 			$bstr_B_find=true;
 		break;
 		}
@@ -2441,11 +2455,11 @@ function rewrite($no,$name,$email,$sub,$com,$url,$pwd,$admin){
 	}
 
 	// フォーム内容をチェック
-	if(!$name||preg_match("/^[ |　|]*$/",$name)) $name="";
-	if(!$com||preg_match("/^[ |　|\t]*$/",$com)) $com="";
-	if(!$sub||preg_match("/^[ |　|]*$/",$sub))   $sub="";
-	if(preg_match("/&lt;|</",$email))   $email="";
-	if(!$url||!preg_match("/^ *?https?:\/\//",$url)||preg_match("/&lt;|</",$url))   $url="";
+	if(!$name||preg_match("/\A\s*\z/u",$name)) $name="";
+	if(!$com||preg_match("/\A\s*\z/u",$com)) $com="";
+	if(!$sub||preg_match("/\A\s*\z/u",$sub))   $sub="";
+	if(!$email||preg_match("/\A\s*\z|&lt;|</ui",$email)) $email="";
+	if(!$url||!preg_match("/\A *https?:\/\//",$url)||preg_match("/&lt;|</i",$url)) $url="";
 
 	//$name=preg_replace("/管理/","\"管理\"",$name);
 	//$name=preg_replace("/削除/","\"削除\"",$name);


### PR DESCRIPTION
### 正規表現の見直し

**\s**

>$chk_com  = preg_replace(&#x22;/(\r\n|\r|\n| |&#x3000;)/&#x22;, &#x22;&#x22;, $com );

↓

>$chk_com  = preg_replace(&#x22;/\s/u&#x22;, &#x22;&#x22;, $com );

チェックする文字列から改行、全角スペース、半角スペースを削除にさらにタブ文字を追加…という時点で、\s に書き直し。\sで、全角半角スペース改行タブを指定できるので、長々と書かなくてもよくなりました。
念のため高負荷や誤動作につながらないか数日かけて調べましたが問題はみあたりませんでした。
utf-8では \s で全角スペースもマッチするのでこのエスケープ文字だけで処理できます。

>if(!$com||preg_match(&#x22;/^[ |&#x3000;|\t]*$/&#x22;,$com)) $com=&#x22;&#x22;;

↓

>if(!$com||preg_match(&#x22;/\A\s*\z/u&#x22;,$com)) $com=&#x22;&#x22;;

改行が入ると、スペースと改行しかなくても文字が入力されたことになっていたのを修正しました。

>https://blog.tokumaru.org/2014/03/z.html

\A と \zは入力の先頭と末尾。

**/ui**

>修飾子は競合しないので複数設定可能です。 https://teratail.com/questions/40884

>if(preg_match(&#x22;/$value/ui&#x22;,$chk_com){
}

Unicodeで、かつ大文字小文字を区別しない。
修飾子をUnicodeにした時に /i の大文字小文字を区別しないが有効にならなくなっていたのを修正しました。

### ツールパレット左右切り替え

PaintBBS NEO v1.5.5の新機能、ツールパレットの表示位置左右切り替えに対応。
iPad+Apple Pencilで描く時に右手がツールに接触して色が意図せず変わるなどの誤動作が起きるのを防止するためのもの。

デフォルトスキンneeにこちらで組み込んでみましたが、暫定的な組み込みになりますので必要に応じてさこつさんのほうで改良していただけたら…と思います。

![Screen-2020-04-13_15-30-00](https://user-images.githubusercontent.com/44894014/79097899-d4188100-7d9b-11ea-9147-761800f6c6a6.png)

ツールパレットが左に移動してもデザインが崩れないようにするため、キャンバスの最小値を100pxから300pxに変更しました。