### PR TITLE
コード整理

### DIFF
--- a/potiboard/potiboard.php
+++ b/potiboard/potiboard.php
@@ -3,7 +3,7 @@
 //$time_start = microtime(true);
 /*
   *
-  * POTI-board改 v1.55.6 lot.200505
+  * POTI-board改 v1.55.7 lot.200510
   *   (C)sakots >> https://sakots.red/poti/
   *
   *----------------------------------------------------------------------------------
@@ -191,8 +191,8 @@ if(!defined('ELAPSED_DAYS')){//config.phpで未定義なら0
 define('USE_MB' , '1');
 
 //バージョン
-define('POTI_VER' , '改 v1.55.6');
-define('POTI_VERLOT' , '改 v1.55.6 lot.200505');
+define('POTI_VER' , '改 v1.55.7');
+define('POTI_VERLOT' , '改 v1.55.7 lot.200510');
 
 //メール通知クラスのファイル名
 define('NOTICEMAIL_FILE' , 'noticemail.inc');
@@ -632,9 +632,10 @@ unset($value);
 				if(RES_UPLOAD){
 					//画像テーブル作成
 					$imgline=array();
-					//$counttreeline = count($treeline);//190619
-					for($k = $s; $k < $counttreeline; $k++){
-						$disptree = $treeline[$k];
+					foreach($treeline as $k => $disptree){
+						if($k<$s){//レス表示件数
+							continue;
+						}
 						$j=$lineindex[$disptree] - 1;
 						if($line[$j]==="") continue;
 						list(,,,,,,,,,$rext,,,$rtime,,,) = explode(",", rtrim($line[$j]));
@@ -697,9 +698,10 @@ unset($value);
 
 			//レス作成
 			$rres=array();
-			$counttreeline = count($treeline);
-			for($k = $s; $k < $counttreeline; $k++){
-				$disptree = $treeline[$k];
+			foreach($treeline as $k => $disptree){
+				if($k<$s){//レス表示件数
+					continue;
+				}
 				$j=$lineindex[$disptree] - 1;
 				if($line[$j]==="") continue;
 				list($no,$now,$name,$email,$sub,$com,$url,


### PR DESCRIPTION
レス2件省略　全部読むにはペイントボタンを(以下略)のような表示にするかどうかを設定する箇所に関わるコードを整理しました。

> //レス画像貼りを許可した場合の画像付きレスを表示させる件数
> define('DSP_RESIMG', '2');
> 

> //1スレ内のレス表示件数(0で全件表示)
> //[新規投稿は管理者のみ]にした場合の 0 はレスを表示しません
> define('DSP_RES', '5');
> 

どちらも設定通りに動作する事を確認しました。

ツリーファイルのカウントが重複していてもわかりにくい。
for文だと配列の反復である事がわかりにくい。
↓
foreach