### PR TITLE
config.php

### DIFF
--- a/potiboard/config.php
+++ b/potiboard/config.php
@@ -176,7 +176,7 @@ define('UNDO_IN_MG', '45');
 //・保存タイプが AUTOの場合、JPEGに変換
 //・保存タイプが PNG の場合、減色処理
 //ただし、保存タイプが JPEGの場合は、この値を無視してJPEGに変換
-	define('IMAGE_SIZE', '800');
+define('IMAGE_SIZE', '800');
 
 //PNGの減色率とJPEGの圧縮率
 define('COMPRESS_LEVEL', '15');

--- a/potiboard/config.php
+++ b/potiboard/config.php
@@ -146,7 +146,7 @@ define('USER_DEL', '1');
 
 /* ---------- ADD:2004/03/16 ---------- */
 //文字色選択を使用する する:1 しない:0
-//0を推奨
+//要対応テンプレート
 define('USE_FONTCOLOR', '0');
 
 //レスで画像貼りを許可する する:1 しない:0
@@ -176,7 +176,7 @@ define('UNDO_IN_MG', '45');
 //・保存タイプが AUTOの場合、JPEGに変換
 //・保存タイプが PNG の場合、減色処理
 //ただし、保存タイプが JPEGの場合は、この値を無視してJPEGに変換
-define('IMAGE_SIZE', '800');
+	define('IMAGE_SIZE', '800');
 
 //PNGの減色率とJPEGの圧縮率
 define('COMPRESS_LEVEL', '15');
@@ -230,7 +230,7 @@ define('SEND_COM', '0');
 
 /* ---------- メイン設定 ---------- */
 
-//ログファイル名　変更しないとわかる人にはログが丸見え
+//ログファイル名
 define('LOGFILE', 'img.log');
 define('TREEFILE', 'tree.log');
 
@@ -284,7 +284,7 @@ define('MAX_SUB', '100');
 define('MAX_COM', '1000');
 
 //一ページに表示する記事
-define('PAGE_DEF', '7');
+define('PAGE_DEF', '10');
 
 //最大ログ数
 define('LOG_MAX', '400');
@@ -342,9 +342,9 @@ define('USE_RESUB', '1');
 define('RES_FORM', '0');
 
 //フォーム下の追加お知らせ
-//(例)'<LI>お知らせデース
-//     <LI>サーバの規約で<font color=red><big><B>アダルト禁止</B></big></font>'
-//使わないことを推奨
+//(例)'<li>お知らせデース</li>
+//     <li>サーバの規約でアダルト禁止</li>'
+//要対応テンプレート
 $addinfo='';
 
 //拒絶する文字列
@@ -363,11 +363,9 @@ $badip = array("addr.dummy.com","addr2.dummy.com");
 /* ---------- サムネイル設定 ---------- */
 
 //サムネイルを作成する する:1 しない:0
-define('USE_THUMB', '0');
+define('USE_THUMB', '1');
 
 //サムネイルルーチンの指定 自動判別:0 GD版:1 
-//自動判別は万能じゃありません
-//なるべくチェックスクリプトで調べてから直に指定して下さい
 define('THUMB_SELECT', '0');
 
 //サムネイルの品質  0(品質は最低、サイズは小)～100(品質は最高、サイズは大)の範囲内
@@ -378,7 +376,7 @@ define('THUMB_Q', '75');
 define('RE_SAMPLED', '1');
 
 //強制サムネイル機能を使用する する:1 しない:0
-define('FORCED_THUMB', '1');
+define('FORCED_THUMB', '0');
 
 //強制サムネイル判定用 ファイル容量KB
 //これを超えると強制的にサムネイル


### PR DESCRIPTION
> //ログファイル名


ログファイルの場所がわかっても見えないように一応なってはいます。

potiboard.phpの

> function init(){//初期化時
> (中略)
> if(is_file(realpath($value)))chmod($value,0600);
> 

パーミッションが600で、末尾の数字が0なのでブラウザから閲覧できない。

同梱の.htaccess

> &#x3C;files ~ &#x22;(^config\.php$|\.(ini|log|dat)$)&#x22;&#x3E;order allow,deny
> &#x9;deny from all
> &#x3C;/files&#x3E;
> 

拡張子が(ini|log|dat)のいずれかの場合はブラウザから閲覧できない。


> //サムネイルを作成する する:1 しない:0
> define('USE_THUMB', '1');
> 
> //強制サムネイル機能を使用する する:1 しない:0
> define('FORCED_THUMB', '0');
> 

サムネイルは作成するが、強制サムネイルは使わない。
強制サムネイルを使うと、

> //これを超えると強制的にサムネイル
> define('IMG_SIZE', '60');
> 

が発動して縮小しないサイズの範囲内でもサムネイル化してJPEG劣化を起こす。
しかし大きな画像のアップロードも許可するならサムネイル機能は必要だと思います。

> //&#x30D5;&#x30A9;&#x30FC;&#x30E0;&#x4E0B;&#x306E;&#x8FFD;&#x52A0;&#x304A;&#x77E5;&#x3089;&#x305B;
> //(&#x4F8B;)&#x27;&#x3C;li&#x3E;&#x304A;&#x77E5;&#x3089;&#x305B;&#x30C7;&#x30FC;&#x30B9;&#x3C;/li&#x3E;
> //&#x8981;&#x5BFE;&#x5FDC;&#x30C6;&#x30F3;&#x30D7;&#x30EC;&#x30FC;&#x30C8;
> $addinfo=&#x27;&#x27;;
> 

MONO WHITE、PINK、Cool Solidでは$addinfoが有効というか使っている方がいるので要対応テンプレートとしました。
しかしfontタグの入ったサンプルは適切ではないので書き直しました。

> //文字色選択を使用する する:1 しない:0
> //要対応テンプレート
> define('USE_FONTCOLOR', '0');
> 

HTML5+CSSで色を変更しているテンプレート「Cool Solid」もあるので対応テンプレートがあれば…。

> //一ページに表示する記事
> define('PAGE_DEF', '10');
> 

5では少ないと思っていましたが1ページに表示する件数なので10に。

細かくて申し訳けないです…。
気になった箇所をまとめてプルリクしました。
採用の可否の判断はおまかせします。